### PR TITLE
Add peppi_py to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ fancyflags
 pyarrow
 git+https://github.com/vladfi1/py7zr.git@dev
 parameterized
+peppi_py


### PR DESCRIPTION
After creating a virtual env and running `pip install -r requirements.txt`, I get the following error while trying to build a local dataset:

```
$ python parse_local.py --help
Traceback (most recent call last):
  File "/home/trstruth/projects/slippi-ai/slippi_db/parse_local.py", line 41, in <module>
    import peppi_py
ModuleNotFoundError: No module named 'peppi_py'
```

This PR introduces `peppi_py` to the requirements file