### PR TITLE
Normalize player display names in netplay.py

### DIFF
--- a/scripts/netplay.py
+++ b/scripts/netplay.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+import unicodedata
 import logging
 
 from absl import app
@@ -68,7 +69,8 @@ def main(_):
     display_name = user_json['displayName']
 
     name_to_port = {
-        player.displayName: port for port, player in gamestate.players.items()
+        # player.displayName: port for port, player in gamestate.players.items()
+        unicodedata.normalize('NFKC', player.displayName): port for port, player in gamestate.players.items()
     }
 
     actual_port = name_to_port[display_name]


### PR DESCRIPTION
Imported the `unicodedata` module to support Unicode normalization of player display names.

Updated the mapping of player display names to ports by normalizing each `player.displayName` using the 'NFKC' normalization form.