### PR TITLE
Add simulator env

### DIFF
--- a/scripts/run_evaluator.py
+++ b/scripts/run_evaluator.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
   NUM_ENVS = flags.DEFINE_integer('num_envs', 1, 'Number of environments.')
 
   FAKE_ENVS = flags.DEFINE_boolean('fake_envs', False, 'Use fake environments.')
+  SIM_ENVS = flags.DEFINE_boolean('sim_envs', False, 'Use melee-sim-light environments.')
   ASYNC_ENVS = flags.DEFINE_boolean('async_envs', False, 'Use async environments.')
   NUM_ENV_STEPS = flags.DEFINE_integer(
       'num_env_steps', 0, 'Number of environment steps to batch.')
@@ -46,6 +47,50 @@ if __name__ == '__main__':
 
   TF_PROFILE = flags.DEFINE_boolean('tf_profile', False, 'Enable TF profiler.')
   JAX_PROFILER_DIR = flags.DEFINE_string('jax_profiler_dir', None, 'Directory for JAX profiler traces.')
+  NUM_GAMES = flags.DEFINE_integer(
+      'num_games', 0, 'Stop after this many initially active sim games finish.')
+
+  def print_game_summary(games: list[dict]):
+    # Sim envs expose completed-game records directly, so this summary reports
+    # game-level outcomes instead of inferring strength from rollout reward.
+    if not games:
+      print('completed games: 0')
+      return
+
+    wins = sum(game['winner_port'] == 1 for game in games)
+    losses = sum(game['winner_port'] == 2 for game in games)
+    ties = sum(game['winner_port'] is None for game in games)
+    timeouts = sum(game['max_frame_reached'] for game in games)
+    stockouts = sum(game['stockout'] for game in games)
+    lengths = [game['frames'] for game in games]
+    stocks = [game['stocks'] for game in games]
+    print(
+        'completed games: '
+        f'total={len(games)} wins={wins} losses={losses} ties={ties} '
+        f'win_rate={wins / len(games):.3f}')
+    print(
+        'game endings: '
+        f'stockouts={stockouts} timeouts={timeouts}')
+    print(
+        'game length: '
+        f'avg_frames={sum(lengths) / len(lengths):.1f} '
+        f'avg_seconds={sum(lengths) / len(lengths) / 60:.1f}')
+    print(
+        'final stocks: '
+        f'player={sum(s[0] for s in stocks) / len(stocks):.2f} '
+        f'opponent={sum(s[1] for s in stocks) / len(stocks):.2f}')
+    stages = sorted({game['stage'] for game in games})
+    for stage in stages:
+      stage_games = [game for game in games if game['stage'] == stage]
+      stage_wins = sum(game['winner_port'] == 1 for game in stage_games)
+      stage_losses = sum(game['winner_port'] == 2 for game in stage_games)
+      stage_ties = sum(game['winner_port'] is None for game in stage_games)
+      stage_lengths = [game['frames'] for game in stage_games]
+      print(
+          f'stage {stage}: total={len(stage_games)} '
+          f'wins={stage_wins} losses={stage_losses} ties={stage_ties} '
+          f'win_rate={stage_wins / len(stage_games):.3f} '
+          f'avg_frames={sum(stage_lengths) / len(stage_lengths):.1f}')
 
   def main(_):
     player_kwargs = {
@@ -87,8 +132,11 @@ if __name__ == '__main__':
         env_kwargs=env_kwargs,
         use_gpu=USE_GPU.value,
         use_fake_envs=FAKE_ENVS.value,
+        use_sim_envs=SIM_ENVS.value,
         damage_ratio=0,
     )
+    if NUM_GAMES.value and not SIM_ENVS.value:
+      raise ValueError('--num_games currently requires --sim_envs.')
 
     evaluator = evaluators.Evaluator(**evaluator_kwargs)
 
@@ -106,9 +154,44 @@ if __name__ == '__main__':
         import jax
         jax.profiler.start_trace(JAX_PROFILER_DIR.value)
 
+      cohort = None
+      cohort_results = {}
+      if NUM_GAMES.value:
+        # Measure a fixed cohort of already-started games. Replacement games
+        # after resets are ignored so "100 games" means the first 100 selected
+        # games finished, not the first 100 short games to finish.
+        active_games = evaluator.active_sim_games()
+        if NUM_GAMES.value > len(active_games):
+          raise ValueError(
+              '--num_games cannot exceed --num_envs for unbiased cohort eval.')
+        cohort = {
+            (game['env_id'], game['episode_id'])
+            for game in active_games[:NUM_GAMES.value]
+        }
+
       timer = utils.Profiler(burnin=0)
+      rewards = {}
+      completed_games = []
+      total_steps = 0
       with timer:
-        stats, metrics = evaluator.rollout(ROLLOUT_LENGTH.value, verbose=True)
+        while True:
+          stats, metrics = evaluator.rollout(ROLLOUT_LENGTH.value, verbose=True)
+          total_steps += ROLLOUT_LENGTH.value
+          for port, stat in stats.items():
+            rewards[port] = rewards.get(port, 0) + stat.reward
+          if cohort is None:
+            completed_games.extend(metrics.get('completed_games', []))
+          else:
+            # Completed-game metadata carries (env_id, episode_id), which lets
+            # us keep collecting long games from the original cohort while
+            # discarding later episodes from the same env lanes.
+            for game in metrics.get('completed_games', []):
+              key = (game['env_id'], game['episode_id'])
+              if key in cohort:
+                cohort_results[key] = game
+            completed_games = list(cohort_results.values())
+          if not NUM_GAMES.value or len(completed_games) >= NUM_GAMES.value:
+            break
 
       if TF_PROFILE.value:
         import tensorflow as tf
@@ -118,16 +201,21 @@ if __name__ == '__main__':
         import jax
         jax.profiler.stop_trace()
 
-    num_frames = NUM_ENVS.value * ROLLOUT_LENGTH.value
-    num_minutes = num_frames / (60 * 60)
-    kdpm = stats[1].reward / num_minutes
+    env_frames = NUM_ENVS.value * total_steps
+    player_frames = env_frames * len(players)
+    num_minutes = env_frames / (60 * 60)
+    kdpm = rewards[1] / num_minutes
     print('ko diff per minute:', kdpm)
+    print_game_summary(completed_games)
 
     timings = metrics['timing']
     print('timings:', utils.map_single_structure(lambda f: f'{f * 1000:.3f}', timings))
 
-    sps = ROLLOUT_LENGTH.value / timer.cumtime
-    fps = sps * NUM_ENVS.value
-    print(f'fps: {fps:.2f}, sps: {sps:.2f}')
+    sps = total_steps / timer.cumtime
+    env_fps = env_frames / timer.cumtime
+    player_fps = player_frames / timer.cumtime
+    print(
+        f'env_fps: {env_fps:.2f}, player_fps: {player_fps:.2f}, '
+        f'sps: {sps:.2f}')
 
   app.run(main)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ packages =
     slippi_ai/jax/q
     slippi_ai/jax/nash
     slippi_ai/jax/rl
+    slippi_ai/sim_env
     slippi_ai/tf
     slippi_ai/nash
     slippi_db

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -173,11 +173,11 @@ class RolloutWorker:
     if self._use_fake_envs:
       raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
 
-    characters = tuple(dict.fromkeys(
+    characters = set(
         player.character
         for kwargs in self._dolphin_kwargs
         for player in kwargs['players'].values()
-    ))
+    )
     stages = [kwargs['stage'] for kwargs in self._dolphin_kwargs]
     if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
       stages = tuple(itertools.islice(

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -181,7 +181,7 @@ class RolloutWorker:
     stages = [kwargs['stage'] for kwargs in self._dolphin_kwargs]
     if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
       stages = tuple(itertools.islice(
-          itertools.cycle(sim_env.supported_stages()), self._num_envs))
+          itertools.cycle(sim_env.SUPPORTED_STAGES), self._num_envs))
     max_frame_id = -1 if first_kwargs['infinite_time'] else 8 * 60 * 60 - 123
 
     return sim_env.SimBatchedEnvironment(

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -2,8 +2,10 @@
 
 import collections
 import contextlib
+import itertools
 import typing as tp
 
+import melee
 import numpy as np
 
 from slippi_ai import envs as env_lib
@@ -65,6 +67,7 @@ class RolloutWorker:
       use_gpu: bool = True,
       damage_ratio: float = 0,  # For rewards.
       use_fake_envs: bool = False,
+      use_sim_envs: bool = False,
   ):
     if isinstance(dolphin_kwargs, dict):
       dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(num_envs)]
@@ -108,6 +111,7 @@ class RolloutWorker:
 
     self._num_envs = num_envs
     self._use_fake_envs = use_fake_envs
+    self._use_sim_envs = use_sim_envs
     self._env_kwargs = env_kwargs
     self._async_envs = async_envs
     self._build_env()
@@ -147,7 +151,9 @@ class RolloutWorker:
       self._push_actions()
 
   def _build_env(self):
-    if self._use_fake_envs:
+    if self._use_sim_envs:
+      self._env = self._build_sim_env()
+    elif self._use_fake_envs:
       self._env = env_lib.ReplayBatchedEnvironment(
           self._num_envs, players=list(self._agents))
     else:
@@ -157,6 +163,34 @@ class RolloutWorker:
         env_class = env_lib.AsyncBatchedEnvironmentMP
       self._env = env_class(
           self._num_envs, self._dolphin_kwargs, **self._env_kwargs)
+
+  def _build_sim_env(self):
+    from slippi_ai import sim_env
+
+    first_kwargs = self._dolphin_kwargs[0]
+    if self._async_envs:
+      raise ValueError('Sim envs are single-process; async_envs is not supported.')
+    if self._use_fake_envs:
+      raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
+
+    characters = tuple(dict.fromkeys(
+        player.character
+        for kwargs in self._dolphin_kwargs
+        for player in kwargs['players'].values()
+    ))
+    stages = [kwargs['stage'] for kwargs in self._dolphin_kwargs]
+    if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
+      stages = tuple(itertools.islice(
+          itertools.cycle(sim_env.supported_stages()), self._num_envs))
+    max_frame_id = -1 if first_kwargs['infinite_time'] else 8 * 60 * 60 - 123
+
+    return sim_env.SimBatchedEnvironment(
+        num_envs=self._num_envs,
+        players=first_kwargs['players'],
+        stage=stages,
+        character_pool=characters,
+        max_frame_id=max_frame_id,
+    )
 
   def reset_env(self):
     self._env.stop()

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -168,6 +168,8 @@ class RolloutWorker:
     from slippi_ai import sim_env
 
     first_kwargs = self._dolphin_kwargs[0]
+    # TODO: introduce an env/evaluator config so sim env setup does not have to
+    # reuse Dolphin-specific kwargs as the shared environment configuration.
     if self._async_envs:
       raise ValueError('Sim envs are single-process; async_envs is not supported.')
     if self._use_fake_envs:
@@ -182,6 +184,8 @@ class RolloutWorker:
     if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
       stages = tuple(itertools.islice(
           itertools.cycle(sim_env.SUPPORTED_STAGES), self._num_envs))
+    # melee_sim.MatchConfig defaults to 4 stocks here; DolphinConfig only maps
+    # timer behavior through this bridge.
     max_frame_id = -1 if first_kwargs['infinite_time'] else 8 * 60 * 60 - 123
 
     return sim_env.SimBatchedEnvironment(

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -261,6 +261,9 @@ class RolloutWorker:
     else:
       step_iter = range(num_steps)
 
+    if hasattr(self._env, 'pop_completed_games'):
+      self._env.pop_completed_games()
+
     for _ in step_iter:
       # Note that there will always be a first gamestate before any actions
       # are fed into the environment; either the initial state or the last
@@ -336,6 +339,8 @@ class RolloutWorker:
         timing=timings,
         unexpected_reset=is_resetting[1:],
     )
+    if hasattr(self._env, 'pop_completed_games'):
+      metrics['completed_games'] = self._env.pop_completed_games()
 
     # self._env_push_profiler.dump_stats('env_push.prof')
 
@@ -346,6 +351,11 @@ class RolloutWorker:
   ):
     for port, values in updates.items():
       self._agents[port].policy.set_state(values)
+
+  def active_sim_games(self) -> list[dict[str, int | str]]:
+    if not hasattr(self._env, 'active_games'):
+      raise ValueError('active_sim_games is only available with use_sim_envs.')
+    return self._env.active_games()
 
   @contextlib.contextmanager
   def run(self):

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -265,8 +265,7 @@ def concise_name(name: str) -> str:
 
 def reset_optimizer_steps(imitation_state: dict):
   for key in ['policy_optimizer', 'value_optimizer']:
-    if key in imitation_state['state']:
-      imitation_state['state'][key]['step'] = 0
+    imitation_state['state'][key]['step'] = 0
 
 
 def run(config: Config):
@@ -413,12 +412,12 @@ def run(config: Config):
         itertools.cycle(char_combinations), batch_size))
 
     main_agent_chars, opp_agent_chars = zip(*char_combination_batch)
-    for main_player, opp_player, main_char, opp_char in zip(
-        main_players, opponent_players, main_agent_chars, opp_agent_chars):
-      if main_char is not None:
-        main_player.character = main_char
-      if opp_char is not None:
-        opp_player.character = opp_char
+    for player, char in zip(main_players, main_agent_chars):
+      if char is not None:
+        player.character = char
+    for player, char in zip(opponent_players, opp_agent_chars):
+      if char is not None:
+        player.character = char
 
   dolphin_kwargs = [
       dict(

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -53,6 +53,7 @@ class ActorConfig:
   inner_batch_size: int = 1
   gpu_inference: bool = True
   use_fake_envs: bool = False
+  use_sim_envs: bool = False
 
 
 @dataclasses.dataclass
@@ -262,7 +263,8 @@ def concise_name(name: str) -> str:
 
 def reset_optimizer_steps(imitation_state: dict):
   for key in ['policy_optimizer', 'value_optimizer']:
-    imitation_state['state'][key]['step'] = 0
+    if key in imitation_state['state']:
+      imitation_state['state'][key]['step'] = 0
 
 
 def run(config: Config):
@@ -409,12 +411,12 @@ def run(config: Config):
         itertools.cycle(char_combinations), batch_size))
 
     main_agent_chars, opp_agent_chars = zip(*char_combination_batch)
-    for player, main_char, opp_char in zip(
-        opponent_players, main_agent_chars, opp_agent_chars):
+    for main_player, opp_player, main_char, opp_char in zip(
+        main_players, opponent_players, main_agent_chars, opp_agent_chars):
       if main_char is not None:
-        player.character = main_char
+        main_player.character = main_char
       if opp_char is not None:
-        player.character = opp_char
+        opp_player.character = opp_char
 
   dolphin_kwargs = [
       dict(
@@ -433,6 +435,14 @@ def run(config: Config):
         inner_batch_size=config.actor.inner_batch_size,
     )
 
+  if config.actor.use_sim_envs:
+    if config.actor.use_fake_envs:
+      raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
+    if config.actor.async_envs:
+      raise ValueError('Sim envs are single-process; async_envs is not supported.')
+    if config.opponent.type == OpponentType.CPU:
+      raise ValueError('Sim env only supports AI-vs-AI opponents.')
+
   build_actor = lambda: evaluators.RolloutWorker(
       agent_kwargs=agent_kwargs,
       dolphin_kwargs=dolphin_kwargs,
@@ -441,6 +451,7 @@ def run(config: Config):
       async_envs=config.actor.async_envs,
       use_gpu=config.actor.gpu_inference,
       use_fake_envs=config.actor.use_fake_envs,
+      use_sim_envs=config.actor.use_sim_envs,
   )
 
   learner_manager = LearnerManager(

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -224,6 +224,8 @@ class LearnerManager:
         trajectories.append(trajectory)
         actor_metrics.append(timings)
 
+      for metrics in actor_metrics:
+        metrics.pop('completed_games', None)
       actor_metrics = utils.map_nt(
           lambda *xs: np.mean(xs), *actor_metrics)
 

--- a/slippi_ai/sim_env/__init__.py
+++ b/slippi_ai/sim_env/__init__.py
@@ -1,0 +1,31 @@
+from slippi_ai.sim_env.env import (
+    SUPPORTED_CHARACTERS,
+    SUPPORTED_STAGES,
+    CharacterPool,
+    Controllers,
+    Port,
+    SimBatchedEnvironment,
+    SimStepInfo,
+    copy_encoded_controller,
+    neutral_controllers,
+    supported_stages,
+    terminal_view,
+    write_encoded_controller_action,
+)
+from slippi_ai.sim_env.observations import GameBatch
+
+__all__ = (
+    'SUPPORTED_CHARACTERS',
+    'SUPPORTED_STAGES',
+    'CharacterPool',
+    'Controllers',
+    'GameBatch',
+    'Port',
+    'SimBatchedEnvironment',
+    'SimStepInfo',
+    'copy_encoded_controller',
+    'neutral_controllers',
+    'supported_stages',
+    'terminal_view',
+    'write_encoded_controller_action',
+)

--- a/slippi_ai/sim_env/__init__.py
+++ b/slippi_ai/sim_env/__init__.py
@@ -6,11 +6,7 @@ from slippi_ai.sim_env.env import (
     Port,
     SimBatchedEnvironment,
     SimStepInfo,
-    copy_encoded_controller,
     neutral_controllers,
-    supported_stages,
-    terminal_view,
-    write_encoded_controller_action,
 )
 from slippi_ai.sim_env.observations import GameBatch
 
@@ -23,9 +19,5 @@ __all__ = (
     'Port',
     'SimBatchedEnvironment',
     'SimStepInfo',
-    'copy_encoded_controller',
     'neutral_controllers',
-    'supported_stages',
-    'terminal_view',
-    'write_encoded_controller_action',
 )

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -27,8 +27,8 @@ import numpy as np
 from slippi_ai import dolphin
 from slippi_ai.envs import EnvOutput
 from slippi_ai.sim_env.observations import (
-    GameBatch, copy_controller_slice as _copy_controller_slice, game_for_port,
-    make_game_batch_buffers,
+    GameBatch, GameBatchBuffers,
+    copy_controller_slice as _copy_controller_slice, game_for_port,
 )
 from slippi_ai.types import Buttons, Controller, Stick
 
@@ -101,6 +101,11 @@ class SimBatchedEnvironment:
   ):
     self._num_envs = int(num_envs)
     self._length = int(length)
+    self._max_frame_id = int(max_frame_id)
+    self.num_steps = 1
+
+    # The sim adapter currently exposes the singles shape used by the policy:
+    # port 1 and port 2, no teams, one controlled character per port.
     if players is None:
       self._players = {
           1: dolphin.AI(melee.Character.FOX),
@@ -111,12 +116,64 @@ class SimBatchedEnvironment:
     self._ports = tuple(sorted(self._players))
     if self._ports != _SUPPORTED_PORTS:
       raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
-    self._stage_by_env = _normalize_stages(stage, self._num_envs)
-    self._character_assignments = _character_assignments(
-        character_pool, self._players, self._num_envs)
-    self._max_frame_id = int(max_frame_id)
-    self.num_steps = 1
 
+    # `stage` can be one value for every lane or an explicit per-env list.
+    if isinstance(stage, melee.Stage):
+      stages = [stage] * self._num_envs
+    else:
+      stages = list(stage)
+      if len(stages) != self._num_envs:
+        raise ValueError(f'stage sequence must have length num_envs={self._num_envs}')
+    for item in stages:
+      if item not in SUPPORTED_STAGES:
+        raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
+    self._stage_by_env = np.asarray(stages, dtype=object)
+
+    # Default to the explicit player matchup everywhere. If a pool is supplied,
+    # cycle lanes through the ordered singles matchup matrix. Resets keep each
+    # lane's initial matchup until we intentionally add randomized reset-time
+    # assignment later.
+    if character_pool is None:
+      character_assignments = (
+          (
+              _coerce_character(self._players[1].character),
+              _coerce_character(self._players[2].character),
+          ),
+      ) * self._num_envs
+    else:
+      if isinstance(character_pool, str):
+        characters = tuple(
+            _coerce_character(name.strip())
+            for name in character_pool.split(',')
+            if name.strip())
+      else:
+        characters = tuple(_coerce_character(character) for character in character_pool)
+      pool = tuple(dict.fromkeys(characters))
+      if not pool:
+        raise ValueError('character pool must not be empty')
+      unsupported = tuple(
+          character for character in pool if character not in SUPPORTED_CHARACTERS)
+      if unsupported:
+        raise ValueError(
+            f'unsupported sim character pool {pool!r}; '
+            f'supported characters are {SUPPORTED_CHARACTERS}')
+      matrix = tuple(itertools.product(pool, repeat=2))
+      character_assignments = tuple(
+          matrix[i % len(matrix)] for i in range(self._num_envs))
+
+    match_configs = [
+        melee_sim.MatchConfig(
+            stage=_MELEE_TO_SIM_STAGE[stage],
+            players=(
+                melee_sim.PlayerConfig(character=int(char_pair[0].value)),
+                melee_sim.PlayerConfig(character=int(char_pair[1].value)),
+            ),
+        )
+        for stage, char_pair in zip(self._stage_by_env, character_assignments)
+    ]
+
+    # Native buffers own the rollout ring. Python keeps views into them and only
+    # writes controller actions / reads observations at the current cursor.
     self._env = melee_sim.EnvBatch(
         batch_size=self._num_envs,
         length=self._length,
@@ -124,22 +181,27 @@ class SimBatchedEnvironment:
         data_dir=data_dir,
     )
     self._buffers = self._env.buffers(action_format='controller')
-    self._configure_all_matches()
+    self._env.configure_matches(self._buffers, match_configs)
     self._env.bind(self._buffers)
     self._env.reset_all()
 
+    # Previous-controller observations are policy-visible, so they live beside
+    # the native env and are reset for lanes as games finish.
     self._last_controllers = {
         port: neutral_controllers(self._num_envs) for port in self._ports
     }
-    # The policy observes previous controller state. Keep these buffers live so
-    # encoded-action rollout can update history without rebuilding Game trees.
+
     self._last_step_info = SimStepInfo(
         terminal=np.zeros(self._num_envs, dtype=_TERMINAL_DTYPE),
         step_t=-1,
     )
     self._episode_ids = np.zeros(self._num_envs, dtype=np.int64)
     self._completed_games: list[dict[str, tp.Any]] = []
-    self._game_batch = make_game_batch_buffers(self._num_envs)
+
+    # Reusable policy-facing observation tree for the high-throughput path.
+    self._game_batch = GameBatchBuffers(self._num_envs)
+
+    # Match the existing env push/pop contract by seeding an initial observation.
     self._output_queue = collections.deque([
         self.current_state(needs_reset=np.ones(self._num_envs, dtype=np.bool_))
     ])
@@ -158,7 +220,10 @@ class SimBatchedEnvironment:
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
     frame = self._buffers.gamestate_view[self._env.t]
     return EnvOutput(
-        gamestates={port: self._game_for_port(frame, port) for port in self._ports},
+        gamestates={
+            port: game_for_port(frame, port, self._last_controllers)
+            for port in self._ports
+        },
         needs_reset=np.asarray(needs_reset, dtype=np.bool_),
     )
 
@@ -185,7 +250,11 @@ class SimBatchedEnvironment:
     self._env.reset_masked()
     reset_mask[self._env.t, ids] = 0
     self._episode_ids[ids] += 1
-    self._reset_last_controllers(ids)
+    if ids.size:
+      neutral = neutral_controllers(ids.size)
+      for port in self._ports:
+        _copy_controller_slice(
+            self._last_controllers[port], neutral, ids, slice(None))
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_)
     needs_reset[ids] = True
     return self.current_state(needs_reset=needs_reset)
@@ -296,7 +365,14 @@ class SimBatchedEnvironment:
     action = self._buffers.controller_action_view[self._env.t]
     for player_index, port in enumerate(self._ports):
       controller = controllers[port]
-      _write_controller_action(action, controller, player_index)
+      player = action['p'][:, int(player_index)]
+      player['main_stick_x'][:] = controller.main_stick.x
+      player['main_stick_y'][:] = controller.main_stick.y
+      player['c_stick_x'][:] = controller.c_stick.x
+      player['c_stick_y'][:] = controller.c_stick.y
+      player['shoulder'][:] = controller.shoulder
+      for name in Buttons._fields:
+        player['buttons'][name][:] = getattr(controller.buttons, name)
       _copy_controller_slice(
           self._last_controllers[port],
           controller,
@@ -325,6 +401,12 @@ class SimBatchedEnvironment:
       env_slot1 = slot1[env_id]
       stocks = (int(env_slot0['stocks']), int(env_slot1['stocks']))
       percents = (float(env_slot0['percent']), float(env_slot1['percent']))
+      if stocks[0] != stocks[1]:
+        winner_port = 1 if stocks[0] > stocks[1] else 2
+      elif percents[0] != percents[1]:
+        winner_port = 1 if percents[0] < percents[1] else 2
+      else:
+        winner_port = None
       terminal_row = terminal[env_id]
       stage = self._stage_by_env[env_id]
       self._completed_games.append({
@@ -334,7 +416,7 @@ class SimBatchedEnvironment:
           'stage_id': int(stage.value),
           'frame_id': int(terminal_row['frame_id']),
           'frames': max(0, int(terminal_row['frame_id']) + 123),
-          'winner_port': _winner_port(stocks, percents),
+          'winner_port': winner_port,
           'stocks': stocks,
           'percents': percents,
           'match_ended': bool(terminal_row['match_ended']),
@@ -346,39 +428,9 @@ class SimBatchedEnvironment:
     if self._env.t >= self._length:
       self._env.reset_cursor()
 
-  def _reset_last_controllers(self, ids: np.ndarray):
-    if ids.size == 0:
-      return
-    neutral = neutral_controllers(ids.size)
-    for port in self._ports:
-      _copy_controller_slice(self._last_controllers[port], neutral, ids, slice(None))
-
   def _reset_finished_lanes_for_next_observation(self, needs_reset: np.ndarray):
     if np.any(needs_reset):
       self.reset(np.flatnonzero(needs_reset))
-
-  def _configure_all_matches(self):
-    self._env.configure_matches(
-        self._buffers,
-        [
-            melee_sim.MatchConfig(
-                stage=_MELEE_TO_SIM_STAGE[stage],
-                players=(
-                    melee_sim.PlayerConfig(character=int(char_pair[0].value)),
-                    melee_sim.PlayerConfig(character=int(char_pair[1].value)),
-                ),
-            )
-            for stage, char_pair in zip(self._stage_by_env, self._character_assignments)
-        ],
-    )
-
-  def _game_for_port(self, frame: np.ndarray, port: Port):
-    return game_for_port(
-        frame,
-        port,
-        self._last_controllers,
-    )
-
 
 def neutral_controllers(batch_size: int) -> Controller:
   shape = (int(batch_size),)
@@ -409,61 +461,6 @@ def terminal_view(buffers: melee_sim.Buffers) -> np.ndarray:
       .view(_TERMINAL_DTYPE)
       .reshape(raw.shape[0], raw.shape[1])
   )
-
-
-def supported_stages() -> tuple[melee.Stage, ...]:
-  return SUPPORTED_STAGES
-
-
-def _normalize_character_pool(character_pool: CharacterPool) -> tuple[melee.Character, ...]:
-  if isinstance(character_pool, str):
-    characters = tuple(
-        _coerce_character(name.strip())
-        for name in character_pool.split(',')
-        if name.strip())
-  else:
-    characters = tuple(_coerce_character(character) for character in character_pool)
-
-  deduped = tuple(dict.fromkeys(characters))
-  if not deduped:
-    raise ValueError('character pool must not be empty')
-  unsupported = tuple(
-      character for character in deduped if character not in SUPPORTED_CHARACTERS)
-  if unsupported:
-    raise ValueError(
-        f'unsupported sim character pool {deduped!r}; '
-        f'supported characters are {SUPPORTED_CHARACTERS}')
-  return deduped
-
-
-def _character_assignments(
-    character_pool: CharacterPool | None,
-    players: tp.Mapping[int, dolphin.Player],
-    num_envs: int,
-) -> tuple[tuple[melee.Character, melee.Character], ...]:
-  if character_pool is None:
-    matchup = (
-        _coerce_character(players[1].character),
-        _coerce_character(players[2].character),
-    )
-    return (matchup,) * int(num_envs)
-
-  pool = _normalize_character_pool(character_pool)
-  # For now, keep assignment deterministic and simple: cycle env lanes through
-  # the ordered singles matchup matrix. Reset keeps each lane's initial matchup.
-  matrix = tuple(itertools.product(pool, repeat=2))
-  return tuple(matrix[i % len(matrix)] for i in range(int(num_envs)))
-
-
-def _write_controller_action(action_frame: np.ndarray, controller: Controller, player_index: int):
-  player = action_frame['p'][:, int(player_index)]
-  player['main_stick_x'][:] = controller.main_stick.x
-  player['main_stick_y'][:] = controller.main_stick.y
-  player['c_stick_x'][:] = controller.c_stick.x
-  player['c_stick_y'][:] = controller.c_stick.y
-  player['shoulder'][:] = controller.shoulder
-  for name in Buttons._fields:
-    player['buttons'][name][:] = getattr(controller.buttons, name)
 
 
 def write_encoded_controller_action(
@@ -506,51 +503,6 @@ def copy_encoded_controller(
   dst.shoulder[:] = np.asarray(src.shoulder)[source_slice] * scale_shoulder
   for name in Buttons._fields:
     getattr(dst.buttons, name)[:] = np.asarray(getattr(src.buttons, name))[source_slice]
-
-
-def _normalize_stages(stage: melee.Stage | tp.Sequence[melee.Stage], num_envs: int) -> np.ndarray:
-  if isinstance(stage, melee.Stage):
-    stages = [stage] * num_envs
-  else:
-    stages = list(stage)
-    if len(stages) != num_envs:
-      raise ValueError(f'stage sequence must have length num_envs={num_envs}')
-  for item in stages:
-    if item not in SUPPORTED_STAGES:
-      raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
-  return np.asarray(stages, dtype=object)
-
-
-def _winner_port(
-    stocks: tuple[int, int],
-    percents: tuple[float, float],
-) -> int | None:
-  if stocks[0] != stocks[1]:
-    return 1 if stocks[0] > stocks[1] else 2
-  if percents[0] != percents[1]:
-    return 1 if percents[0] < percents[1] else 2
-  return None
-
-
-def _slot_for_source(slots: np.ndarray, source_player: int) -> np.ndarray:
-  for slot_index in range(slots.shape[1]):
-    slot = slots[:, slot_index]
-    present = slot['present'].astype(np.bool_)
-    source = slot['source_player']
-    if np.all((~present) | (source == int(source_player))) and np.any(present):
-      return slot
-  raise RuntimeError(f'melee_sim gamestate did not contain source player {source_player}')
-
-
-def _winner_port(
-    stocks: tuple[int, int],
-    percents: tuple[float, float],
-) -> int | None:
-  if stocks[0] != stocks[1]:
-    return 1 if stocks[0] > stocks[1] else 2
-  if percents[0] != percents[1]:
-    return 1 if percents[0] < percents[1] else 2
-  return None
 
 
 def _slot_for_source(slots: np.ndarray, source_player: int) -> np.ndarray:

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -1,0 +1,512 @@
+"""Single-process melee-sim-light environment adapter.
+
+This module is the direct bridge from `melee_sim.EnvBatch` native buffers to the
+slippi-ai `Game`/`Controller` structures used by policies. It owns the Python
+API for a batched sim env, including stage and character-pool setup, reset
+handling, terminal side-channel views, and conversion from native SoA buffers to
+the libmelee-shaped observation nest.
+
+There are two use modes. `current_state`/`step` preserve the familiar
+port-keyed Dolphin env interface for tests and small tools. The high-throughput
+path uses `current_game_batch` and `step_encoded`: one reusable `GameBatch`
+stores all port-1 perspectives followed by all port-2 perspectives, and policy
+action buckets are decoded straight into the native action ring. That path avoids
+rebuilding Python game objects during rollout and is what the JAX sim pipeline
+uses.
+"""
+
+import collections
+import contextlib
+import itertools
+import typing as tp
+
+import melee
+import melee_sim
+import numpy as np
+
+from slippi_ai import dolphin
+from slippi_ai.envs import EnvOutput
+from slippi_ai.sim_env.observations import (
+    GameBatch, copy_controller_slice as _copy_controller_slice, game_for_port,
+    make_game_batch_buffers,
+)
+from slippi_ai.types import Buttons, Controller, Stick
+
+
+Port = int
+Controllers = tp.Mapping[Port, Controller]
+
+_SUPPORTED_PORTS = (1, 2)
+_MELEE_TO_SIM_STAGE = {
+    melee.Stage.FOUNTAIN_OF_DREAMS: melee_sim.Stage.FOUNTAIN_OF_DREAMS,
+    melee.Stage.POKEMON_STADIUM: melee_sim.Stage.POKEMON_STADIUM,
+    melee.Stage.YOSHIS_STORY: melee_sim.Stage.YOSHIS_STORY,
+    melee.Stage.DREAMLAND: melee_sim.Stage.DREAM_LAND_N64,
+    melee.Stage.BATTLEFIELD: melee_sim.Stage.BATTLEFIELD,
+    melee.Stage.FINAL_DESTINATION: melee_sim.Stage.FINAL_DESTINATION,
+}
+SUPPORTED_STAGES = tuple(
+    stage for stage in _MELEE_TO_SIM_STAGE
+    if stage is not melee.Stage.FOUNTAIN_OF_DREAMS
+)
+# FoD stays out of the default sim stage set until its MSL behavior is verified
+# enough for policy training.
+SUPPORTED_CHARACTERS = (
+    melee.Character.FOX,
+    melee.Character.FALCO,
+)
+_CHARACTER_BY_NAME = {
+    character.name.lower(): character for character in SUPPORTED_CHARACTERS
+}
+
+_TERMINAL_DTYPE = np.dtype(
+    [
+        ('frame_id', '<i4'),
+        ('stage_id', '<u4'),
+        ('done', 'u1'),
+        ('match_ended', 'u1'),
+        ('stockout', 'u1'),
+        ('max_frame_reached', 'u1'),
+        ('alive_count', 'u1'),
+        ('alive_team_count', 'u1'),
+        ('team_alive_mask', 'u1'),
+        ('_pad0', 'u1'),
+    ],
+    align=False,
+)
+
+
+class SimStepInfo(tp.NamedTuple):
+  terminal: np.ndarray
+  step_t: int
+
+
+CharacterPool = str | tp.Sequence[melee.Character | str | int]
+
+
+class SimBatchedEnvironment:
+  """Batched melee_sim-backed environment using slippi-ai Game objects.
+
+  The public env shape mirrors the Dolphin-backed envs: callers pass controller
+  actions and receive `EnvOutput` objects. High-throughput paths should use
+  `current_game_batch` and `step_encoded` to avoid rebuilding per-port Python
+  objects while still feeding the same policy-facing fields.
+  """
+
+  def __init__(
+      self,
+      num_envs: int,
+      players: tp.Mapping[int, dolphin.Player] | None = None,
+      *,
+      length: int = 128,
+      stage: melee.Stage | tp.Sequence[melee.Stage] = melee.Stage.FINAL_DESTINATION,
+      character_pool: CharacterPool | None = None,
+      max_frame_id: int = -1,
+      data_dir: str | None = None,
+  ):
+    self._num_envs = int(num_envs)
+    self._length = int(length)
+    if players is None:
+      self._players = {
+          1: dolphin.AI(melee.Character.FOX),
+          2: dolphin.AI(melee.Character.FOX),
+      }
+    else:
+      self._players = players
+    self._ports = tuple(sorted(self._players))
+    if self._ports != _SUPPORTED_PORTS:
+      raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
+    self._stage_by_env = _normalize_stages(stage, self._num_envs)
+    self._character_assignments = _character_assignments(
+        character_pool, self._players, self._num_envs)
+    self._max_frame_id = int(max_frame_id)
+    self.num_steps = 1
+
+    self._env = melee_sim.EnvBatch(
+        batch_size=self._num_envs,
+        length=self._length,
+        num_players=2,
+        data_dir=data_dir,
+    )
+    self._buffers = self._env.buffers(action_format='controller')
+    self._configure_all_matches()
+    self._env.bind(self._buffers)
+    self._env.reset_all()
+
+    self._last_controllers = {
+        port: neutral_controllers(self._num_envs) for port in self._ports
+    }
+    # The policy observes previous controller state. Keep these buffers live so
+    # encoded-action rollout can update history without rebuilding Game trees.
+    self._last_step_info = SimStepInfo(
+        terminal=np.zeros(self._num_envs, dtype=_TERMINAL_DTYPE),
+        step_t=-1,
+    )
+    self._game_batch = make_game_batch_buffers(self._num_envs)
+    self._output_queue = collections.deque([
+        self.current_state(needs_reset=np.ones(self._num_envs, dtype=np.bool_))
+    ])
+
+  def stop(self):
+    self._env.close()
+
+  @contextlib.contextmanager
+  def run(self):
+    try:
+      yield self
+    finally:
+      self.stop()
+
+  def current_state(self, needs_reset: np.ndarray | None = None) -> EnvOutput:
+    needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
+    frame = self._buffers.gamestate_view[self._env.t]
+    return EnvOutput(
+        gamestates={port: self._game_for_port(frame, port) for port in self._ports},
+        needs_reset=np.asarray(needs_reset, dtype=np.bool_),
+    )
+
+  def current_game_batch(self, needs_reset: np.ndarray | None = None) -> GameBatch:
+    """Return a [port1 views, port2 views] game batch for policy calls."""
+    needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
+    frame = self._buffers.gamestate_view[self._env.t]
+    # Reuse one Game nest and mutate its leaves. This is the high-throughput
+    # adapter path from melee_sim's native buffers to the JAX policy input.
+    self._game_batch.fill(frame, needs_reset, self._last_controllers)
+    return GameBatch(
+        game=self._game_batch.game,
+        needs_reset=self._game_batch.needs_reset,
+    )
+
+  def reset(self, env_ids: tp.Sequence[int] | np.ndarray | None = None) -> EnvOutput:
+    ids = np.arange(self._num_envs, dtype=np.int64) if env_ids is None else np.asarray(env_ids, dtype=np.int64)
+    if np.any(ids < 0) or np.any(ids >= self._num_envs):
+      raise ValueError('env_ids contains an out-of-range env index')
+    self._ensure_cursor_room()
+    reset_mask = self._buffers.reset_mask
+    reset_mask[self._env.t, :] = 0
+    reset_mask[self._env.t, ids] = 1
+    self._env.reset_masked()
+    reset_mask[self._env.t, ids] = 0
+    self._reset_last_controllers(ids)
+    needs_reset = np.zeros(self._num_envs, dtype=np.bool_)
+    needs_reset[ids] = True
+    return self.current_state(needs_reset=needs_reset)
+
+  def push(self, controllers: Controllers):
+    self._output_queue.append(self._advance(controllers))
+
+  def pop(self) -> EnvOutput:
+    return self._output_queue.popleft()
+
+  def peek(self) -> EnvOutput:
+    return self._output_queue[0]
+
+  def step(self, controllers: Controllers) -> EnvOutput:
+    return self._advance(controllers)
+
+  def step_encoded(
+      self,
+      controller_state: Controller,
+      *,
+      axis_spacing: int,
+      shoulder_spacing: int,
+  ) -> np.ndarray:
+    """Step from encoded default-controller buckets shaped by port perspective."""
+    self._ensure_cursor_room()
+
+    action = self._buffers.controller_action_view[self._env.t]
+    # Decode policy buckets straight into the native action ring, and mirror the
+    # same decoded values into previous-controller state for the next Game view.
+    write_encoded_controller_action(
+        action,
+        controller_state,
+        player_index=0,
+        source_slice=slice(0, self._num_envs),
+        axis_spacing=axis_spacing,
+        shoulder_spacing=shoulder_spacing,
+    )
+    write_encoded_controller_action(
+        action,
+        controller_state,
+        player_index=1,
+        source_slice=slice(self._num_envs, 2 * self._num_envs),
+        axis_spacing=axis_spacing,
+        shoulder_spacing=shoulder_spacing,
+    )
+    copy_encoded_controller(
+        self._last_controllers[1],
+        controller_state,
+        source_slice=slice(0, self._num_envs),
+        axis_spacing=axis_spacing,
+        shoulder_spacing=shoulder_spacing,
+    )
+    copy_encoded_controller(
+        self._last_controllers[2],
+        controller_state,
+        source_slice=slice(self._num_envs, 2 * self._num_envs),
+        axis_spacing=axis_spacing,
+        shoulder_spacing=shoulder_spacing,
+    )
+
+    step_t = self._env.t
+    self._env.step(max_frame_id=self._max_frame_id)
+    needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
+    self._last_step_info = SimStepInfo(
+        terminal=terminal_view(self._buffers)[step_t].copy(),
+        step_t=step_t,
+    )
+    self._reset_finished_lanes_for_next_observation(needs_reset)
+    return needs_reset
+
+  def multi_step(self, controllers: list[Controllers]) -> list[EnvOutput]:
+    return [self.step(c) for c in controllers]
+
+  @property
+  def buffers(self):
+    return self._buffers
+
+  @property
+  def cursor(self) -> int:
+    return self._env.t
+
+  @property
+  def stages(self) -> np.ndarray:
+    return self._stage_by_env.copy()
+
+  @property
+  def last_step_info(self) -> SimStepInfo:
+    return self._last_step_info
+
+  def _advance(self, controllers: Controllers) -> EnvOutput:
+    self._ensure_cursor_room()
+
+    action = self._buffers.controller_action_view[self._env.t]
+    for player_index, port in enumerate(self._ports):
+      controller = controllers[port]
+      _write_controller_action(action, controller, player_index)
+      _copy_controller_slice(
+          self._last_controllers[port],
+          controller,
+          slice(None),
+          slice(None),
+      )
+
+    step_t = self._env.t
+    self._env.step(max_frame_id=self._max_frame_id)
+    needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
+    self._last_step_info = SimStepInfo(
+        terminal=terminal_view(self._buffers)[step_t].copy(),
+        step_t=step_t,
+    )
+    self._reset_finished_lanes_for_next_observation(needs_reset)
+    return self.current_state(needs_reset=needs_reset)
+
+  def _ensure_cursor_room(self):
+    if self._env.t >= self._length:
+      self._env.reset_cursor()
+
+  def _reset_last_controllers(self, ids: np.ndarray):
+    if ids.size == 0:
+      return
+    neutral = neutral_controllers(ids.size)
+    for port in self._ports:
+      _copy_controller_slice(self._last_controllers[port], neutral, ids, slice(None))
+
+  def _reset_finished_lanes_for_next_observation(self, needs_reset: np.ndarray):
+    if np.any(needs_reset):
+      self.reset(np.flatnonzero(needs_reset))
+
+  def _configure_all_matches(self):
+    self._env.configure_matches(
+        self._buffers,
+        [
+            melee_sim.MatchConfig(
+                stage=_MELEE_TO_SIM_STAGE[stage],
+                players=(
+                    melee_sim.PlayerConfig(character=int(char_pair[0].value)),
+                    melee_sim.PlayerConfig(character=int(char_pair[1].value)),
+                ),
+            )
+            for stage, char_pair in zip(self._stage_by_env, self._character_assignments)
+        ],
+    )
+
+  def _game_for_port(self, frame: np.ndarray, port: Port):
+    return game_for_port(
+        frame,
+        port,
+        self._last_controllers,
+    )
+
+
+def neutral_controllers(batch_size: int) -> Controller:
+  shape = (int(batch_size),)
+  return Controller(
+      main_stick=Stick(
+          x=np.full(shape, 0.5, dtype=np.float32),
+          y=np.full(shape, 0.5, dtype=np.float32),
+      ),
+      c_stick=Stick(
+          x=np.full(shape, 0.5, dtype=np.float32),
+          y=np.full(shape, 0.5, dtype=np.float32),
+      ),
+      shoulder=np.zeros(shape, dtype=np.float32),
+      buttons=Buttons(**{
+          name: np.zeros(shape, dtype=np.bool_)
+          for name in Buttons._fields
+      }),
+  )
+
+
+def terminal_view(buffers: melee_sim.Buffers) -> np.ndarray:
+  """View the native terminal side-channel as a structured NumPy array."""
+  raw = buffers.terminal
+  if raw.shape[2] < _TERMINAL_DTYPE.itemsize:
+    raise ValueError('terminal buffer row is smaller than MslTerminal')
+  return (
+      raw[:, :, :_TERMINAL_DTYPE.itemsize]
+      .view(_TERMINAL_DTYPE)
+      .reshape(raw.shape[0], raw.shape[1])
+  )
+
+
+def supported_stages() -> tuple[melee.Stage, ...]:
+  return SUPPORTED_STAGES
+
+
+def _normalize_character_pool(character_pool: CharacterPool) -> tuple[melee.Character, ...]:
+  if isinstance(character_pool, str):
+    characters = tuple(
+        _coerce_character(name.strip())
+        for name in character_pool.split(',')
+        if name.strip())
+  else:
+    characters = tuple(_coerce_character(character) for character in character_pool)
+
+  deduped = tuple(dict.fromkeys(characters))
+  if not deduped:
+    raise ValueError('character pool must not be empty')
+  unsupported = tuple(
+      character for character in deduped if character not in SUPPORTED_CHARACTERS)
+  if unsupported:
+    raise ValueError(
+        f'unsupported sim character pool {deduped!r}; '
+        f'supported characters are {SUPPORTED_CHARACTERS}')
+  return deduped
+
+
+def _character_assignments(
+    character_pool: CharacterPool | None,
+    players: tp.Mapping[int, dolphin.Player],
+    num_envs: int,
+) -> tuple[tuple[melee.Character, melee.Character], ...]:
+  if character_pool is None:
+    matchup = (
+        _coerce_character(players[1].character),
+        _coerce_character(players[2].character),
+    )
+    return (matchup,) * int(num_envs)
+
+  pool = _normalize_character_pool(character_pool)
+  # For now, keep assignment deterministic and simple: cycle env lanes through
+  # the ordered singles matchup matrix. Reset keeps each lane's initial matchup.
+  matrix = tuple(itertools.product(pool, repeat=2))
+  return tuple(matrix[i % len(matrix)] for i in range(int(num_envs)))
+
+
+def _write_controller_action(action_frame: np.ndarray, controller: Controller, player_index: int):
+  player = action_frame['p'][:, int(player_index)]
+  player['main_stick_x'][:] = controller.main_stick.x
+  player['main_stick_y'][:] = controller.main_stick.y
+  player['c_stick_x'][:] = controller.c_stick.x
+  player['c_stick_y'][:] = controller.c_stick.y
+  player['shoulder'][:] = controller.shoulder
+  for name in Buttons._fields:
+    player['buttons'][name][:] = getattr(controller.buttons, name)
+
+
+def write_encoded_controller_action(
+    action_frame: np.ndarray,
+    controller: Controller,
+    *,
+    player_index: int,
+    source_slice: slice,
+    axis_spacing: int,
+    shoulder_spacing: int,
+):
+  """Decode discretized policy controller buckets into melee_sim actions."""
+  player = action_frame['p'][:, int(player_index)]
+  scale_axis = np.float32(1.0 / float(axis_spacing))
+  scale_shoulder = np.float32(1.0 / float(shoulder_spacing))
+  player['main_stick_x'][:] = np.asarray(controller.main_stick.x)[source_slice] * scale_axis
+  player['main_stick_y'][:] = np.asarray(controller.main_stick.y)[source_slice] * scale_axis
+  player['c_stick_x'][:] = np.asarray(controller.c_stick.x)[source_slice] * scale_axis
+  player['c_stick_y'][:] = np.asarray(controller.c_stick.y)[source_slice] * scale_axis
+  player['shoulder'][:] = np.asarray(controller.shoulder)[source_slice] * scale_shoulder
+  for name in Buttons._fields:
+    player['buttons'][name][:] = np.asarray(getattr(controller.buttons, name))[source_slice]
+
+
+def copy_encoded_controller(
+    dst: Controller,
+    src: Controller,
+    *,
+    source_slice: slice,
+    axis_spacing: int,
+    shoulder_spacing: int,
+):
+  """Decode discretized policy controller buckets into policy-observation state."""
+  scale_axis = np.float32(1.0 / float(axis_spacing))
+  scale_shoulder = np.float32(1.0 / float(shoulder_spacing))
+  dst.main_stick.x[:] = np.asarray(src.main_stick.x)[source_slice] * scale_axis
+  dst.main_stick.y[:] = np.asarray(src.main_stick.y)[source_slice] * scale_axis
+  dst.c_stick.x[:] = np.asarray(src.c_stick.x)[source_slice] * scale_axis
+  dst.c_stick.y[:] = np.asarray(src.c_stick.y)[source_slice] * scale_axis
+  dst.shoulder[:] = np.asarray(src.shoulder)[source_slice] * scale_shoulder
+  for name in Buttons._fields:
+    getattr(dst.buttons, name)[:] = np.asarray(getattr(src.buttons, name))[source_slice]
+
+
+def _normalize_stages(stage: melee.Stage | tp.Sequence[melee.Stage], num_envs: int) -> np.ndarray:
+  if isinstance(stage, melee.Stage):
+    stages = [stage] * num_envs
+  else:
+    stages = list(stage)
+    if len(stages) != num_envs:
+      raise ValueError(f'stage sequence must have length num_envs={num_envs}')
+  for item in stages:
+    if item not in SUPPORTED_STAGES:
+      raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
+  return np.asarray(stages, dtype=object)
+
+
+def _winner_port(
+    stocks: tuple[int, int],
+    percents: tuple[float, float],
+) -> int | None:
+  if stocks[0] != stocks[1]:
+    return 1 if stocks[0] > stocks[1] else 2
+  if percents[0] != percents[1]:
+    return 1 if percents[0] < percents[1] else 2
+  return None
+
+
+def _slot_for_source(slots: np.ndarray, source_player: int) -> np.ndarray:
+  for slot_index in range(slots.shape[1]):
+    slot = slots[:, slot_index]
+    present = slot['present'].astype(np.bool_)
+    source = slot['source_player']
+    if np.all((~present) | (source == int(source_player))) and np.any(present):
+      return slot
+  raise RuntimeError(f'melee_sim gamestate did not contain source player {source_player}')
+
+
+def _coerce_character(character) -> melee.Character:
+  if isinstance(character, melee.Character):
+    return character
+  if isinstance(character, str):
+    try:
+      return _CHARACTER_BY_NAME[character.lower()]
+    except KeyError as exc:
+      raise ValueError(f'unsupported character {character!r}') from exc
+  return melee.Character(character)

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -93,14 +93,14 @@ class SimBatchedEnvironment:
       num_envs: int,
       players: tp.Mapping[int, dolphin.Player] | None = None,
       *,
-      length: int = 128,
+      frame_buffer_length: int = 128,
       stage: melee.Stage | tp.Sequence[melee.Stage] = melee.Stage.FINAL_DESTINATION,
       character_pool: CharacterPool | None = None,
       max_frame_id: int = -1,
       data_dir: str | None = None,
   ):
     self._num_envs = int(num_envs)
-    self._length = int(length)
+    self._frame_buffer_length = int(frame_buffer_length)
     self._max_frame_id = int(max_frame_id)
     self.num_steps = 1
 
@@ -176,7 +176,7 @@ class SimBatchedEnvironment:
     # writes controller actions / reads observations at the current cursor.
     self._env = melee_sim.EnvBatch(
         batch_size=self._num_envs,
-        length=self._length,
+        length=self._frame_buffer_length,
         num_players=2,
         data_dir=data_dir,
     )
@@ -425,7 +425,8 @@ class SimBatchedEnvironment:
       })
 
   def _ensure_cursor_room(self):
-    if self._env.t >= self._length:
+    # Native frame ring size. Cursor wrap does not reset the match.
+    if self._env.t >= self._frame_buffer_length:
       self._env.reset_cursor()
 
   def _reset_finished_lanes_for_next_observation(self, needs_reset: np.ndarray):

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -45,12 +45,7 @@ _MELEE_TO_SIM_STAGE = {
     melee.Stage.BATTLEFIELD: melee_sim.Stage.BATTLEFIELD,
     melee.Stage.FINAL_DESTINATION: melee_sim.Stage.FINAL_DESTINATION,
 }
-SUPPORTED_STAGES = tuple(
-    stage for stage in _MELEE_TO_SIM_STAGE
-    if stage is not melee.Stage.FOUNTAIN_OF_DREAMS
-)
-# FoD stays out of the default sim stage set until its MSL behavior is verified
-# enough for policy training.
+SUPPORTED_STAGES = tuple(_MELEE_TO_SIM_STAGE)
 SUPPORTED_CHARACTERS = (
     melee.Character.FOX,
     melee.Character.FALCO,
@@ -142,6 +137,8 @@ class SimBatchedEnvironment:
         terminal=np.zeros(self._num_envs, dtype=_TERMINAL_DTYPE),
         step_t=-1,
     )
+    self._episode_ids = np.zeros(self._num_envs, dtype=np.int64)
+    self._completed_games: list[dict[str, tp.Any]] = []
     self._game_batch = make_game_batch_buffers(self._num_envs)
     self._output_queue = collections.deque([
         self.current_state(needs_reset=np.ones(self._num_envs, dtype=np.bool_))
@@ -187,6 +184,7 @@ class SimBatchedEnvironment:
     reset_mask[self._env.t, ids] = 1
     self._env.reset_masked()
     reset_mask[self._env.t, ids] = 0
+    self._episode_ids[ids] += 1
     self._reset_last_controllers(ids)
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_)
     needs_reset[ids] = True
@@ -251,10 +249,9 @@ class SimBatchedEnvironment:
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
     needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
-    self._last_step_info = SimStepInfo(
-        terminal=terminal_view(self._buffers)[step_t].copy(),
-        step_t=step_t,
-    )
+    terminal = terminal_view(self._buffers)[step_t].copy()
+    self._last_step_info = SimStepInfo(terminal=terminal, step_t=step_t)
+    self._record_completed_games(terminal, self._buffers.gamestate_view[self._env.t])
     self._reset_finished_lanes_for_next_observation(needs_reset)
     return needs_reset
 
@@ -277,6 +274,22 @@ class SimBatchedEnvironment:
   def last_step_info(self) -> SimStepInfo:
     return self._last_step_info
 
+  def pop_completed_games(self) -> list[dict[str, tp.Any]]:
+    completed_games = self._completed_games
+    self._completed_games = []
+    return completed_games
+
+  def active_games(self) -> list[dict[str, int | str]]:
+    return [
+        {
+            'env_id': env_id,
+            'episode_id': int(self._episode_ids[env_id]),
+            'stage': self._stage_by_env[env_id].name,
+            'stage_id': int(self._stage_by_env[env_id].value),
+        }
+        for env_id in range(self._num_envs)
+    ]
+
   def _advance(self, controllers: Controllers) -> EnvOutput:
     self._ensure_cursor_room()
 
@@ -294,12 +307,40 @@ class SimBatchedEnvironment:
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
     needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
-    self._last_step_info = SimStepInfo(
-        terminal=terminal_view(self._buffers)[step_t].copy(),
-        step_t=step_t,
-    )
+    terminal = terminal_view(self._buffers)[step_t].copy()
+    self._last_step_info = SimStepInfo(terminal=terminal, step_t=step_t)
+    self._record_completed_games(terminal, self._buffers.gamestate_view[self._env.t])
     self._reset_finished_lanes_for_next_observation(needs_reset)
     return self.current_state(needs_reset=needs_reset)
+
+  def _record_completed_games(self, terminal: np.ndarray, frame: np.ndarray):
+    done_ids = np.flatnonzero(terminal['done'])
+    if done_ids.size == 0:
+      return
+    slot0 = _slot_for_source(frame['slots'], 0)
+    slot1 = _slot_for_source(frame['slots'], 1)
+    for env_id in done_ids:
+      env_id = int(env_id)
+      env_slot0 = slot0[env_id]
+      env_slot1 = slot1[env_id]
+      stocks = (int(env_slot0['stocks']), int(env_slot1['stocks']))
+      percents = (float(env_slot0['percent']), float(env_slot1['percent']))
+      terminal_row = terminal[env_id]
+      stage = self._stage_by_env[env_id]
+      self._completed_games.append({
+          'env_id': env_id,
+          'episode_id': int(self._episode_ids[env_id]),
+          'stage': stage.name,
+          'stage_id': int(stage.value),
+          'frame_id': int(terminal_row['frame_id']),
+          'frames': max(0, int(terminal_row['frame_id']) + 123),
+          'winner_port': _winner_port(stocks, percents),
+          'stocks': stocks,
+          'percents': percents,
+          'match_ended': bool(terminal_row['match_ended']),
+          'stockout': bool(terminal_row['stockout']),
+          'max_frame_reached': bool(terminal_row['max_frame_reached']),
+      })
 
   def _ensure_cursor_room(self):
     if self._env.t >= self._length:
@@ -478,6 +519,27 @@ def _normalize_stages(stage: melee.Stage | tp.Sequence[melee.Stage], num_envs: i
     if item not in SUPPORTED_STAGES:
       raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
   return np.asarray(stages, dtype=object)
+
+
+def _winner_port(
+    stocks: tuple[int, int],
+    percents: tuple[float, float],
+) -> int | None:
+  if stocks[0] != stocks[1]:
+    return 1 if stocks[0] > stocks[1] else 2
+  if percents[0] != percents[1]:
+    return 1 if percents[0] < percents[1] else 2
+  return None
+
+
+def _slot_for_source(slots: np.ndarray, source_player: int) -> np.ndarray:
+  for slot_index in range(slots.shape[1]):
+    slot = slots[:, slot_index]
+    present = slot['present'].astype(np.bool_)
+    source = slot['source_player']
+    if np.all((~present) | (source == int(source_player))) and np.any(present):
+      return slot
+  raise RuntimeError(f'melee_sim gamestate did not contain source player {source_player}')
 
 
 def _winner_port(

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -18,8 +18,6 @@ from slippi_ai.types import (
 )
 
 
-Port = int
-
 _SIM_TO_MELEE_STAGE = {
     int(melee_sim.Stage.FOUNTAIN_OF_DREAMS): melee.Stage.FOUNTAIN_OF_DREAMS.value,
     int(melee_sim.Stage.POKEMON_STADIUM): melee.Stage.POKEMON_STADIUM.value,
@@ -36,15 +34,10 @@ class GameBatch(tp.NamedTuple):
   needs_reset: np.ndarray
 
 
-def make_game_batch_buffers(batch_size: int) -> '_GameBatchBuffers':
-  """Create reusable [port1 views, port2 views] policy-game buffers."""
-  return _GameBatchBuffers(batch_size)
-
-
 def game_for_port(
     frame: np.ndarray,
-    port: Port,
-    controllers: tp.Mapping[Port, Controller],
+    port: int,
+    controllers: tp.Mapping[int, Controller],
 ) -> Game:
   """Build the ordinary port-keyed Game view used by EnvOutput."""
   slots_by_source = _slots_by_source(frame['slots'])
@@ -52,15 +45,21 @@ def game_for_port(
   opponent_source = 1 - self_source
   opponent_port = 1 if port == 2 else 2
   batch_size = frame.shape[0]
+  stage = np.zeros(frame['stage_id'].shape, dtype=np.uint8)
+  for sim_stage, melee_stage in _SIM_TO_MELEE_STAGE.items():
+    stage[frame['stage_id'] == sim_stage] = melee_stage
   return Game(
       p0=player_from_slot(slots_by_source[self_source], controllers[port]),
       p1=player_from_slot(slots_by_source[opponent_source], controllers[opponent_port]),
-      stage=_stage_array(frame['stage_id']),
+      stage=stage,
       randall=Randall(
           x=frame['stage']['randall']['x'].astype(np.float32, copy=True),
           y=frame['stage']['randall']['y'].astype(np.float32, copy=True),
       ),
-      fod_platforms=_empty_fod_platforms(batch_size),
+      fod_platforms=FoDPlatforms(
+          left=np.zeros(batch_size, dtype=np.float32),
+          right=np.zeros(batch_size, dtype=np.float32),
+      ),
       items=items_from_frame(frame['items']),
   )
 
@@ -121,11 +120,6 @@ def _slots_by_source(slots: np.ndarray) -> dict[int, np.ndarray]:
   return result
 
 
-def _empty_fod_platforms(batch_size: int) -> FoDPlatforms:
-  zeros_f32 = np.zeros(int(batch_size), dtype=np.float32)
-  return FoDPlatforms(left=zeros_f32.copy(), right=zeros_f32.copy())
-
-
 def _empty_nana(batch_size: int) -> Nana:
   zeros_bool = np.zeros(batch_size, dtype=np.bool_)
   zeros_f32 = np.zeros(batch_size, dtype=np.float32)
@@ -166,14 +160,7 @@ def _canonical_items(items: np.ndarray) -> np.ndarray:
   return np.take_along_axis(items, order, axis=1)
 
 
-def _stage_array(stage_id: np.ndarray) -> np.ndarray:
-  out = np.zeros(stage_id.shape, dtype=np.uint8)
-  for sim_stage, melee_stage in _SIM_TO_MELEE_STAGE.items():
-    out[stage_id == sim_stage] = melee_stage
-  return out
-
-
-class _GameBatchBuffers:
+class GameBatchBuffers:
   """Reusable Game storage for batched policy calls.
 
   The policy sees each env twice: first from port 1's perspective, then from
@@ -189,7 +176,13 @@ class _GameBatchBuffers:
     self._p0_arrays = _player_arrays(self.num_players)
     self._p1_arrays = _player_arrays(self.num_players)
     self._item_arrays = [
-        _item_arrays(self.num_players)
+        {
+            'exists': np.zeros(self.num_players, dtype=np.bool_),
+            'type': np.zeros(self.num_players, dtype=np.uint16),
+            'state': np.zeros(self.num_players, dtype=np.uint8),
+            'x': np.zeros(self.num_players, dtype=np.float32),
+            'y': np.zeros(self.num_players, dtype=np.float32),
+        }
         for _ in Items._fields
     ]
     self._items = Items(**{
@@ -218,7 +211,7 @@ class _GameBatchBuffers:
       self,
       frame: np.ndarray,
       needs_reset: np.ndarray,
-      controllers: tp.Mapping[Port, Controller] | None = None,
+      controllers: tp.Mapping[int, Controller] | None = None,
   ):
     self.fill_slice(frame, needs_reset, slice(0, self.batch_size), controllers)
 
@@ -227,7 +220,7 @@ class _GameBatchBuffers:
       frame: np.ndarray,
       needs_reset: np.ndarray,
       env_slice: slice,
-      controllers: tp.Mapping[Port, Controller] | None = None,
+      controllers: tp.Mapping[int, Controller] | None = None,
       controller_slice: slice | None = None,
   ):
     # Each native env contributes two policy examples: port 1 perspective in the
@@ -336,13 +329,3 @@ def _controller_buffers(batch_size: int) -> Controller:
   controller.c_stick.x[:] = 0.5
   controller.c_stick.y[:] = 0.5
   return controller
-
-
-def _item_arrays(batch_size: int) -> dict[str, np.ndarray]:
-  return {
-      'exists': np.zeros(batch_size, dtype=np.bool_),
-      'type': np.zeros(batch_size, dtype=np.uint16),
-      'state': np.zeros(batch_size, dtype=np.uint8),
-      'x': np.zeros(batch_size, dtype=np.float32),
-      'y': np.zeros(batch_size, dtype=np.float32),
-  }

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -27,6 +27,15 @@ _SIM_TO_MELEE_STAGE = {
     int(melee_sim.Stage.FINAL_DESTINATION): melee.Stage.FINAL_DESTINATION.value,
 }
 
+# melee_sim exposes native C buffers as NumPy structured-array views. Field
+# access like frame["slots"] or slot["percent"] selects dtype field views; these
+# are not dicts.
+FrameView = np.ndarray
+SlotsView = np.ndarray
+PlayerSlotView = np.ndarray
+ItemsView = np.ndarray
+PlayerArrays = dict[str, np.ndarray]
+
 
 class GameBatch(tp.NamedTuple):
   """Policy-facing batch laid out as [all port-1 views, all port-2 views]."""
@@ -35,7 +44,7 @@ class GameBatch(tp.NamedTuple):
 
 
 def game_for_port(
-    frame: np.ndarray,
+    frame: FrameView,
     port: int,
     controllers: tp.Mapping[int, Controller],
 ) -> Game:
@@ -74,7 +83,7 @@ def copy_controller_slice(dst: Controller, src: Controller, target: slice, sourc
     getattr(dst.buttons, name)[target] = getattr(src.buttons, name)[source]
 
 
-def player_from_slot(slot: np.ndarray, controller: Controller) -> Player:
+def player_from_slot(slot: PlayerSlotView, controller: Controller) -> Player:
   """Convert one melee_sim source-player slot into a policy-facing Player."""
   return Player(
       percent=slot['percent'].clip(0, np.iinfo(np.uint16).max).astype(np.uint16),
@@ -92,7 +101,7 @@ def player_from_slot(slot: np.ndarray, controller: Controller) -> Player:
   )
 
 
-def items_from_frame(items: np.ndarray) -> Items:
+def items_from_frame(items: ItemsView) -> Items:
   """Convert melee_sim item slots into the fixed policy-facing item nest."""
   items = _canonical_items(items)
   return Items(**{
@@ -107,7 +116,7 @@ def items_from_frame(items: np.ndarray) -> Items:
   })
 
 
-def _slots_by_source(slots: np.ndarray) -> dict[int, np.ndarray]:
+def _slots_by_source(slots: SlotsView) -> dict[int, PlayerSlotView]:
   result = {}
   for i in range(slots.shape[1]):
     if not np.any(slots[:, i]['present']):
@@ -140,14 +149,14 @@ def _empty_nana(batch_size: int) -> Nana:
   )
 
 
-def _libmelee_jumps_left(slot: np.ndarray) -> np.ndarray:
+def _libmelee_jumps_left(slot: PlayerSlotView) -> np.ndarray:
   raw = np.asarray(slot['jumps_left'], dtype=np.int16)
   airborne_with_ground_jump_available = (np.asarray(slot['on_ground']) == 0) & (raw > 1)
   values = np.where(airborne_with_ground_jump_available, raw - 1, raw)
   return np.maximum(values, 0).astype(np.uint8)
 
 
-def _canonical_items(items: np.ndarray) -> np.ndarray:
+def _canonical_items(items: ItemsView) -> ItemsView:
   # Native item slots are storage slots. Sort into a stable policy-facing order
   # so observations do not depend on item allocator history.
   exists_key = -items['exists'].astype(np.int16)
@@ -209,7 +218,7 @@ class GameBatchBuffers:
 
   def fill(
       self,
-      frame: np.ndarray,
+      frame: FrameView,
       needs_reset: np.ndarray,
       controllers: tp.Mapping[int, Controller] | None = None,
   ):
@@ -217,7 +226,7 @@ class GameBatchBuffers:
 
   def fill_slice(
       self,
-      frame: np.ndarray,
+      frame: FrameView,
       needs_reset: np.ndarray,
       env_slice: slice,
       controllers: tp.Mapping[int, Controller] | None = None,
@@ -258,7 +267,7 @@ class GameBatchBuffers:
     self._fill_items(frame['items'], first)
     self._fill_items(frame['items'], second)
 
-  def _fill_player(self, dst: dict[str, np.ndarray], target: slice, slot: np.ndarray):
+  def _fill_player(self, dst: PlayerArrays, target: slice, slot: PlayerSlotView):
     np.clip(slot['percent'], 0, np.iinfo(np.uint16).max, out=self._percent_tmp)
     dst['percent'][target] = self._percent_tmp
     dst['facing'][target] = slot['facing']
@@ -271,7 +280,7 @@ class GameBatchBuffers:
     dst['shield_strength'][target] = slot['shield_hp']
     dst['on_ground'][target] = slot['on_ground']
 
-  def _fill_stage_like(self, frame: np.ndarray, target: slice):
+  def _fill_stage_like(self, frame: FrameView, target: slice):
     stage = self.game.stage[target]
     stage[:] = 0
     for sim_stage, melee_stage in _SIM_TO_MELEE_STAGE.items():
@@ -281,7 +290,7 @@ class GameBatchBuffers:
     self.game.fod_platforms.left[target] = 0
     self.game.fod_platforms.right[target] = 0
 
-  def _fill_items(self, items: np.ndarray, target: slice):
+  def _fill_items(self, items: ItemsView, target: slice):
     items = _canonical_items(items)
     for i, arrays in enumerate(self._item_arrays):
       src = items[:, i]
@@ -292,7 +301,7 @@ class GameBatchBuffers:
       arrays['y'][target] = src['pos_y']
 
 
-def _player_arrays(batch_size: int) -> dict[str, np.ndarray]:
+def _player_arrays(batch_size: int) -> PlayerArrays:
   arrays = {
       'percent': np.zeros(batch_size, dtype=np.uint16),
       'facing': np.zeros(batch_size, dtype=np.bool_),

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -1,0 +1,348 @@
+"""MSL buffer to slippi-ai observation adapters.
+
+This module converts melee-sim-light native buffer views into the
+`slippi_ai.types.Game` structures consumed by policies. The fast path writes
+into reusable `GameBatch` buffers so rollout can avoid rebuilding Python
+observation objects every step.
+"""
+
+import typing as tp
+
+import melee
+import melee_sim
+import numpy as np
+
+from slippi_ai.types import (
+    Buttons, Controller, FoDPlatforms, Game, Item, Items, Nana, Player, Randall,
+    Stick,
+)
+
+
+Port = int
+
+_SIM_TO_MELEE_STAGE = {
+    int(melee_sim.Stage.FOUNTAIN_OF_DREAMS): melee.Stage.FOUNTAIN_OF_DREAMS.value,
+    int(melee_sim.Stage.POKEMON_STADIUM): melee.Stage.POKEMON_STADIUM.value,
+    int(melee_sim.Stage.YOSHIS_STORY): melee.Stage.YOSHIS_STORY.value,
+    int(melee_sim.Stage.DREAM_LAND_N64): melee.Stage.DREAMLAND.value,
+    int(melee_sim.Stage.BATTLEFIELD): melee.Stage.BATTLEFIELD.value,
+    int(melee_sim.Stage.FINAL_DESTINATION): melee.Stage.FINAL_DESTINATION.value,
+}
+
+
+class GameBatch(tp.NamedTuple):
+  """Policy-facing batch laid out as [all port-1 views, all port-2 views]."""
+  game: Game
+  needs_reset: np.ndarray
+
+
+def make_game_batch_buffers(batch_size: int) -> '_GameBatchBuffers':
+  """Create reusable [port1 views, port2 views] policy-game buffers."""
+  return _GameBatchBuffers(batch_size)
+
+
+def game_for_port(
+    frame: np.ndarray,
+    port: Port,
+    controllers: tp.Mapping[Port, Controller],
+) -> Game:
+  """Build the ordinary port-keyed Game view used by EnvOutput."""
+  slots_by_source = _slots_by_source(frame['slots'])
+  self_source = port - 1
+  opponent_source = 1 - self_source
+  opponent_port = 1 if port == 2 else 2
+  batch_size = frame.shape[0]
+  return Game(
+      p0=player_from_slot(slots_by_source[self_source], controllers[port]),
+      p1=player_from_slot(slots_by_source[opponent_source], controllers[opponent_port]),
+      stage=_stage_array(frame['stage_id']),
+      randall=Randall(
+          x=frame['stage']['randall']['x'].astype(np.float32, copy=True),
+          y=frame['stage']['randall']['y'].astype(np.float32, copy=True),
+      ),
+      fod_platforms=_empty_fod_platforms(batch_size),
+      items=items_from_frame(frame['items']),
+  )
+
+
+def copy_controller_slice(dst: Controller, src: Controller, target: slice, source: slice):
+  dst.main_stick.x[target] = src.main_stick.x[source]
+  dst.main_stick.y[target] = src.main_stick.y[source]
+  dst.c_stick.x[target] = src.c_stick.x[source]
+  dst.c_stick.y[target] = src.c_stick.y[source]
+  dst.shoulder[target] = src.shoulder[source]
+  for name in Buttons._fields:
+    getattr(dst.buttons, name)[target] = getattr(src.buttons, name)[source]
+
+
+def player_from_slot(slot: np.ndarray, controller: Controller) -> Player:
+  """Convert one melee_sim source-player slot into a policy-facing Player."""
+  return Player(
+      percent=slot['percent'].clip(0, np.iinfo(np.uint16).max).astype(np.uint16),
+      facing=slot['facing'].astype(np.bool_, copy=True),
+      x=slot['pos_x'].astype(np.float32, copy=True),
+      y=slot['pos_y'].astype(np.float32, copy=True),
+      action=slot['action_id'].astype(np.uint16, copy=True),
+      invulnerable=slot['invulnerable'].astype(np.bool_, copy=True),
+      character=slot['char_id'].astype(np.uint8, copy=True),
+      jumps_left=_libmelee_jumps_left(slot),
+      shield_strength=slot['shield_hp'].astype(np.float32, copy=True),
+      on_ground=slot['on_ground'].astype(np.bool_, copy=True),
+      controller=controller,
+      nana=_empty_nana(slot.shape[0]),
+  )
+
+
+def items_from_frame(items: np.ndarray) -> Items:
+  """Convert melee_sim item slots into the fixed policy-facing item nest."""
+  items = _canonical_items(items)
+  return Items(**{
+      f'item_{i}': Item(
+          exists=items[:, i]['exists'].astype(np.bool_, copy=True),
+          type=items[:, i]['type'].astype(np.uint16, copy=True),
+          state=items[:, i]['state'].astype(np.uint8, copy=True),
+          x=items[:, i]['pos_x'].astype(np.float32, copy=True),
+          y=items[:, i]['pos_y'].astype(np.float32, copy=True),
+      )
+      for i in range(len(Items._fields))
+  })
+
+
+def _slots_by_source(slots: np.ndarray) -> dict[int, np.ndarray]:
+  result = {}
+  for i in range(slots.shape[1]):
+    if not np.any(slots[:, i]['present']):
+      continue
+    source = slots[:, i]['source_player']
+    if np.all(source == source[0]):
+      result[int(source[0])] = slots[:, i]
+  if 0 not in result or 1 not in result:
+    raise RuntimeError('melee_sim gamestate did not contain source players 0 and 1')
+  return result
+
+
+def _empty_fod_platforms(batch_size: int) -> FoDPlatforms:
+  zeros_f32 = np.zeros(int(batch_size), dtype=np.float32)
+  return FoDPlatforms(left=zeros_f32.copy(), right=zeros_f32.copy())
+
+
+def _empty_nana(batch_size: int) -> Nana:
+  zeros_bool = np.zeros(batch_size, dtype=np.bool_)
+  zeros_f32 = np.zeros(batch_size, dtype=np.float32)
+  zeros_u16 = np.zeros(batch_size, dtype=np.uint16)
+  zeros_u8 = np.zeros(batch_size, dtype=np.uint8)
+  return Nana(
+      exists=zeros_bool.copy(),
+      percent=zeros_u16.copy(),
+      facing=zeros_bool.copy(),
+      x=zeros_f32.copy(),
+      y=zeros_f32.copy(),
+      action=zeros_u16.copy(),
+      invulnerable=zeros_bool.copy(),
+      character=zeros_u8.copy(),
+      jumps_left=zeros_u8.copy(),
+      shield_strength=zeros_f32.copy(),
+      on_ground=zeros_bool.copy(),
+  )
+
+
+def _libmelee_jumps_left(slot: np.ndarray) -> np.ndarray:
+  raw = np.asarray(slot['jumps_left'], dtype=np.int16)
+  airborne_with_ground_jump_available = (np.asarray(slot['on_ground']) == 0) & (raw > 1)
+  values = np.where(airborne_with_ground_jump_available, raw - 1, raw)
+  return np.maximum(values, 0).astype(np.uint8)
+
+
+def _canonical_items(items: np.ndarray) -> np.ndarray:
+  # Native item slots are storage slots. Sort into a stable policy-facing order
+  # so observations do not depend on item allocator history.
+  exists_key = -items['exists'].astype(np.int16)
+  type_key = -items['type'].astype(np.int32)
+  index_key = np.broadcast_to(
+      np.arange(items.shape[1], dtype=np.int16),
+      items.shape,
+  )
+  order = np.lexsort((index_key, type_key, exists_key), axis=1)
+  return np.take_along_axis(items, order, axis=1)
+
+
+def _stage_array(stage_id: np.ndarray) -> np.ndarray:
+  out = np.zeros(stage_id.shape, dtype=np.uint8)
+  for sim_stage, melee_stage in _SIM_TO_MELEE_STAGE.items():
+    out[stage_id == sim_stage] = melee_stage
+  return out
+
+
+class _GameBatchBuffers:
+  """Reusable Game storage for batched policy calls.
+
+  The policy sees each env twice: first from port 1's perspective, then from
+  port 2's perspective. Keeping this storage live lets rollout code fill arrays
+  in place instead of allocating a fresh Game nest for every frame.
+  """
+
+  def __init__(self, batch_size: int):
+    self.batch_size = int(batch_size)
+    self.num_players = self.batch_size * 2
+    self.needs_reset = np.zeros(self.num_players, dtype=np.bool_)
+    self._percent_tmp = np.zeros(self.batch_size, dtype=np.float32)
+    self._p0_arrays = _player_arrays(self.num_players)
+    self._p1_arrays = _player_arrays(self.num_players)
+    self._item_arrays = [
+        _item_arrays(self.num_players)
+        for _ in Items._fields
+    ]
+    self._items = Items(**{
+        f'item_{i}': Item(**arrays)
+        for i, arrays in enumerate(self._item_arrays)
+    })
+    self._p0_controller = _controller_buffers(self.num_players)
+    self._p1_controller = _controller_buffers(self.num_players)
+    empty_nana = _empty_nana(self.num_players)
+    self.game = Game(
+        p0=Player(**self._p0_arrays, controller=self._p0_controller, nana=empty_nana),
+        p1=Player(**self._p1_arrays, controller=self._p1_controller, nana=empty_nana),
+        stage=np.zeros(self.num_players, dtype=np.uint8),
+        randall=Randall(
+            x=np.zeros(self.num_players, dtype=np.float32),
+            y=np.zeros(self.num_players, dtype=np.float32),
+        ),
+        fod_platforms=FoDPlatforms(
+            left=np.zeros(self.num_players, dtype=np.float32),
+            right=np.zeros(self.num_players, dtype=np.float32),
+        ),
+        items=self._items,
+    )
+
+  def fill(
+      self,
+      frame: np.ndarray,
+      needs_reset: np.ndarray,
+      controllers: tp.Mapping[Port, Controller] | None = None,
+  ):
+    self.fill_slice(frame, needs_reset, slice(0, self.batch_size), controllers)
+
+  def fill_slice(
+      self,
+      frame: np.ndarray,
+      needs_reset: np.ndarray,
+      env_slice: slice,
+      controllers: tp.Mapping[Port, Controller] | None = None,
+      controller_slice: slice | None = None,
+  ):
+    # Each native env contributes two policy examples: port 1 perspective in the
+    # first half and port 2 perspective in the second. p0 is the controlled
+    # player and p1 is the opponent in both halves.
+    first = env_slice
+    second = slice(
+        self.batch_size + int(env_slice.start or 0),
+        self.batch_size + int(env_slice.stop),
+    )
+    local_batch = int(env_slice.stop) - int(env_slice.start or 0)
+    if self._percent_tmp.shape[0] != local_batch:
+      self._percent_tmp = np.zeros(local_batch, dtype=np.float32)
+    self.needs_reset[first] = needs_reset
+    self.needs_reset[second] = needs_reset
+
+    slots_by_source = _slots_by_source(frame['slots'])
+    src0 = slots_by_source[0]
+    src1 = slots_by_source[1]
+    self._fill_player(self._p0_arrays, first, src0)
+    self._fill_player(self._p0_arrays, second, src1)
+    self._fill_player(self._p1_arrays, first, src1)
+    self._fill_player(self._p1_arrays, second, src0)
+    if controllers is not None:
+      # Controller history is perspective-local: p0 sees its own previous
+      # controller and p1 sees the opponent's previous controller.
+      source = env_slice if controller_slice is None else controller_slice
+      copy_controller_slice(self._p0_controller, controllers[1], first, source)
+      copy_controller_slice(self._p0_controller, controllers[2], second, source)
+      copy_controller_slice(self._p1_controller, controllers[2], first, source)
+      copy_controller_slice(self._p1_controller, controllers[1], second, source)
+
+    self._fill_stage_like(frame, first)
+    self._fill_stage_like(frame, second)
+    self._fill_items(frame['items'], first)
+    self._fill_items(frame['items'], second)
+
+  def _fill_player(self, dst: dict[str, np.ndarray], target: slice, slot: np.ndarray):
+    np.clip(slot['percent'], 0, np.iinfo(np.uint16).max, out=self._percent_tmp)
+    dst['percent'][target] = self._percent_tmp
+    dst['facing'][target] = slot['facing']
+    dst['x'][target] = slot['pos_x']
+    dst['y'][target] = slot['pos_y']
+    dst['action'][target] = slot['action_id']
+    dst['invulnerable'][target] = slot['invulnerable']
+    dst['character'][target] = slot['char_id']
+    dst['jumps_left'][target] = _libmelee_jumps_left(slot)
+    dst['shield_strength'][target] = slot['shield_hp']
+    dst['on_ground'][target] = slot['on_ground']
+
+  def _fill_stage_like(self, frame: np.ndarray, target: slice):
+    stage = self.game.stage[target]
+    stage[:] = 0
+    for sim_stage, melee_stage in _SIM_TO_MELEE_STAGE.items():
+      stage[frame['stage_id'] == sim_stage] = melee_stage
+    self.game.randall.x[target] = frame['stage']['randall']['x']
+    self.game.randall.y[target] = frame['stage']['randall']['y']
+    self.game.fod_platforms.left[target] = 0
+    self.game.fod_platforms.right[target] = 0
+
+  def _fill_items(self, items: np.ndarray, target: slice):
+    items = _canonical_items(items)
+    for i, arrays in enumerate(self._item_arrays):
+      src = items[:, i]
+      arrays['exists'][target] = src['exists']
+      arrays['type'][target] = src['type']
+      arrays['state'][target] = src['state']
+      arrays['x'][target] = src['pos_x']
+      arrays['y'][target] = src['pos_y']
+
+
+def _player_arrays(batch_size: int) -> dict[str, np.ndarray]:
+  arrays = {
+      'percent': np.zeros(batch_size, dtype=np.uint16),
+      'facing': np.zeros(batch_size, dtype=np.bool_),
+      'x': np.zeros(batch_size, dtype=np.float32),
+      'y': np.zeros(batch_size, dtype=np.float32),
+      'action': np.zeros(batch_size, dtype=np.uint16),
+      'invulnerable': np.zeros(batch_size, dtype=np.bool_),
+      'character': np.zeros(batch_size, dtype=np.uint8),
+      'jumps_left': np.zeros(batch_size, dtype=np.uint8),
+      'shield_strength': np.zeros(batch_size, dtype=np.float32),
+      'on_ground': np.zeros(batch_size, dtype=np.bool_),
+  }
+  return arrays
+
+
+def _controller_buffers(batch_size: int) -> Controller:
+  controller = Controller(
+      main_stick=Stick(
+          x=np.zeros(batch_size, dtype=np.float32),
+          y=np.zeros(batch_size, dtype=np.float32),
+      ),
+      c_stick=Stick(
+          x=np.zeros(batch_size, dtype=np.float32),
+          y=np.zeros(batch_size, dtype=np.float32),
+      ),
+      shoulder=np.zeros(batch_size, dtype=np.float32),
+      buttons=Buttons(**{
+          name: np.zeros(batch_size, dtype=np.bool_)
+          for name in Buttons._fields
+      }),
+  )
+  controller.main_stick.x[:] = 0.5
+  controller.main_stick.y[:] = 0.5
+  controller.c_stick.x[:] = 0.5
+  controller.c_stick.y[:] = 0.5
+  return controller
+
+
+def _item_arrays(batch_size: int) -> dict[str, np.ndarray]:
+  return {
+      'exists': np.zeros(batch_size, dtype=np.bool_),
+      'type': np.zeros(batch_size, dtype=np.uint16),
+      'state': np.zeros(batch_size, dtype=np.uint8),
+      'x': np.zeros(batch_size, dtype=np.float32),
+      'y': np.zeros(batch_size, dtype=np.float32),
+  }

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -28,7 +28,7 @@ class SimEnvTest(unittest.TestCase):
             1: dolphin.AI(melee.Character.FOX),
             2: dolphin.AI(melee.Character.FALCO),
         },
-        length=8,
+        frame_buffer_length=8,
     )
     try:
       initial = env.current_state()
@@ -85,7 +85,7 @@ class SimEnvTest(unittest.TestCase):
       env.stop()
 
   def test_push_pop_queue_and_partial_reset(self):
-    env = self._sim_env(num_envs=2, length=4)
+    env = self._sim_env(num_envs=2, frame_buffer_length=4)
     try:
       first = env.pop()
       self.assertTrue(np.all(first.needs_reset))
@@ -106,7 +106,7 @@ class SimEnvTest(unittest.TestCase):
       env.stop()
 
   def test_partial_reset_clears_observed_previous_controllers(self):
-    env = self._sim_env(num_envs=2, length=8)
+    env = self._sim_env(num_envs=2, frame_buffer_length=8)
     try:
       controllers = {
           1: sim_env.neutral_controllers(2),
@@ -135,7 +135,7 @@ class SimEnvTest(unittest.TestCase):
         melee.Stage.BATTLEFIELD,
         melee.Stage.YOSHIS_STORY,
     ]
-    env = self._sim_env(num_envs=3, length=2, stage=stages)
+    env = self._sim_env(num_envs=3, frame_buffer_length=2, stage=stages)
     try:
       current = env.current_state()
       self.assertEqual(current.gamestates[1].stage.tolist(), [stage.value for stage in stages])
@@ -161,7 +161,7 @@ class SimEnvTest(unittest.TestCase):
   def test_per_env_character_pool(self):
     env = self._sim_env(
         num_envs=4,
-        length=8,
+        frame_buffer_length=8,
         character_pool='fox,falco',
     )
     try:
@@ -191,7 +191,7 @@ class SimEnvTest(unittest.TestCase):
   def test_character_pool_assignment_stays_fixed_on_reset(self):
     env = self._sim_env(
         num_envs=1,
-        length=8,
+        frame_buffer_length=8,
         character_pool='fox,falco',
     )
     try:
@@ -212,7 +212,7 @@ class SimEnvTest(unittest.TestCase):
       env.stop()
 
   def test_max_frame_terminal_is_reported_separately(self):
-    env = self._sim_env(num_envs=2, length=128, max_frame_id=0)
+    env = self._sim_env(num_envs=2, frame_buffer_length=128, max_frame_id=0)
     try:
       controllers = {
           1: sim_env.neutral_controllers(2),
@@ -237,7 +237,7 @@ class SimEnvTest(unittest.TestCase):
             1: dolphin.AI(melee.Character.FOX),
             2: dolphin.AI(melee.Character.FALCO),
         },
-        length=8,
+        frame_buffer_length=8,
     )
     try:
       state = env.current_game_batch(
@@ -280,7 +280,7 @@ class SimEnvTest(unittest.TestCase):
             1: dolphin.AI(melee.Character.FOX),
             2: dolphin.AI(melee.Character.FALCO),
         },
-        length=8,
+        frame_buffer_length=8,
         stage=[
             melee.Stage.FINAL_DESTINATION,
             melee.Stage.BATTLEFIELD,

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -1,0 +1,414 @@
+import unittest
+
+import melee
+import numpy as np
+
+from slippi_ai import dolphin
+from slippi_ai import sim_env
+from slippi_ai.sim_env import observations
+from slippi_ai.types import Buttons, Controller, Items, Stick
+
+
+class SimEnvTest(unittest.TestCase):
+
+  def _sim_env(self, *args, **kwargs):
+    try:
+      return sim_env.SimBatchedEnvironment(*args, **kwargs)
+    except MemoryError as exc:
+      if 'msl_batch_create failed' not in str(exc):
+        raise
+      self.skipTest(
+          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
+          'extracted melee-sim-light data directory before running sim env tests.')
+
+  def test_current_state_and_step_match_existing_game_shape(self):
+    env = self._sim_env(
+        num_envs=3,
+        players={
+            1: dolphin.AI(melee.Character.FOX),
+            2: dolphin.AI(melee.Character.FALCO),
+        },
+        length=8,
+    )
+    try:
+      initial = env.current_state()
+      self.assertEqual(set(initial.gamestates), {1, 2})
+      self.assertEqual(initial.needs_reset.shape, (3,))
+      self.assertTrue(np.all(initial.gamestates[1].p1.shield_strength == 60.0))
+      self.assertEqual(
+          initial.gamestates[1].p0.character.tolist(),
+          [
+              melee.Character.FOX.value,
+              melee.Character.FOX.value,
+              melee.Character.FOX.value,
+          ],
+      )
+      self.assertEqual(
+          initial.gamestates[1].p1.character.tolist(),
+          [
+              melee.Character.FALCO.value,
+              melee.Character.FALCO.value,
+              melee.Character.FALCO.value,
+          ],
+      )
+      self.assertTrue(np.all(initial.gamestates[1].p0.jumps_left == 1))
+      self.assertFalse(np.any(initial.gamestates[1].items.item_0.exists))
+      self.assertEqual(
+          initial.gamestates[2].p0.character.tolist(),
+          [
+              melee.Character.FALCO.value,
+              melee.Character.FALCO.value,
+              melee.Character.FALCO.value,
+          ],
+      )
+      self.assertEqual(
+          initial.gamestates[2].p1.character.tolist(),
+          [
+              melee.Character.FOX.value,
+              melee.Character.FOX.value,
+              melee.Character.FOX.value,
+          ],
+      )
+
+      controllers = {
+          1: sim_env.neutral_controllers(3),
+          2: sim_env.neutral_controllers(3),
+      }
+      output = env.step(controllers)
+      self.assertEqual(output.gamestates[1].p0.x.shape, (3,))
+      self.assertTrue(np.all(output.gamestates[1].stage == melee.Stage.FINAL_DESTINATION.value))
+      self.assertTrue(np.all(output.gamestates[1].p0.controller.main_stick.x == 0.5))
+      self.assertTrue(np.all(output.gamestates[2].p0.controller.main_stick.x == 0.5))
+      self.assertTrue(np.all(output.gamestates[1].p0.action >= 0))
+      self.assertGreaterEqual(env.cursor, 1)
+    finally:
+      env.stop()
+
+  def test_push_pop_queue_and_partial_reset(self):
+    env = self._sim_env(num_envs=2, length=4)
+    try:
+      first = env.pop()
+      self.assertTrue(np.all(first.needs_reset))
+
+      controllers = {
+          1: sim_env.neutral_controllers(2),
+          2: sim_env.neutral_controllers(2),
+      }
+      env.push(controllers)
+      stepped = env.pop()
+      self.assertFalse(np.any(stepped.needs_reset))
+
+      reset = env.reset([1])
+      self.assertFalse(reset.needs_reset[0])
+      self.assertTrue(reset.needs_reset[1])
+      self.assertEqual(reset.gamestates[1].p0.x.shape, (2,))
+    finally:
+      env.stop()
+
+  def test_partial_reset_clears_observed_previous_controllers(self):
+    env = self._sim_env(num_envs=2, length=8)
+    try:
+      controllers = {
+          1: sim_env.neutral_controllers(2),
+          2: sim_env.neutral_controllers(2),
+      }
+      controllers[1].main_stick.x[:] = [0.0, 1.0]
+      controllers[2].main_stick.x[:] = [0.25, 0.75]
+      env.step(controllers)
+
+      env.reset([1])
+      state = env.current_game_batch(
+          needs_reset=np.array([False, True], dtype=np.bool_))
+
+      self.assertTrue(np.allclose(state.game.p0.controller.main_stick.x, [
+          0.0,
+          0.5,
+          0.25,
+          0.5,
+      ]))
+    finally:
+      env.stop()
+
+  def test_stage_assignment_cursor_wrap_and_controller_write(self):
+    stages = [
+        melee.Stage.FINAL_DESTINATION,
+        melee.Stage.BATTLEFIELD,
+        melee.Stage.YOSHIS_STORY,
+    ]
+    env = self._sim_env(num_envs=3, length=2, stage=stages)
+    try:
+      current = env.current_state()
+      self.assertEqual(current.gamestates[1].stage.tolist(), [stage.value for stage in stages])
+
+      controllers = {
+          1: sim_env.neutral_controllers(3),
+          2: sim_env.neutral_controllers(3),
+      }
+      controllers[1].main_stick.x[:] = [0.0, 0.25, 1.0]
+      controllers[1].buttons.B[:] = [True, False, True]
+      env.step(controllers)
+      action = env.buffers.controller_action_view[0]['p'][:, 0]
+      self.assertTrue(np.allclose(action['main_stick_x'], [0.0, 0.25, 1.0]))
+      self.assertEqual(action['buttons']['B'].tolist(), [1, 0, 1])
+
+      env.step(controllers)
+      self.assertEqual(env.cursor, 2)
+      env.step(controllers)
+      self.assertEqual(env.cursor, 1)
+    finally:
+      env.stop()
+
+  def test_per_env_character_pool(self):
+    env = self._sim_env(
+        num_envs=4,
+        length=8,
+        character_pool='fox,falco',
+    )
+    try:
+      state = env.current_game_batch(
+          needs_reset=np.ones(4, dtype=np.bool_))
+      self.assertEqual(
+          state.game.p0.character[:4].tolist(),
+          [
+              melee.Character.FOX.value,
+              melee.Character.FOX.value,
+              melee.Character.FALCO.value,
+              melee.Character.FALCO.value,
+          ],
+      )
+      self.assertEqual(
+          state.game.p0.character[4:].tolist(),
+          [
+              melee.Character.FOX.value,
+              melee.Character.FALCO.value,
+              melee.Character.FOX.value,
+              melee.Character.FALCO.value,
+          ],
+      )
+    finally:
+      env.stop()
+
+  def test_character_pool_assignment_stays_fixed_on_reset(self):
+    env = self._sim_env(
+        num_envs=1,
+        length=8,
+        character_pool='fox,falco',
+    )
+    try:
+      state = env.current_game_batch(np.ones(1, dtype=np.bool_))
+      self.assertEqual(state.game.p0.character.tolist(), [
+          melee.Character.FOX.value,
+          melee.Character.FOX.value,
+      ])
+
+      state = env.reset([0]).gamestates[1]
+      self.assertEqual(state.p0.character.tolist(), [melee.Character.FOX.value])
+      self.assertEqual(state.p1.character.tolist(), [melee.Character.FOX.value])
+
+      state = env.reset([0]).gamestates[1]
+      self.assertEqual(state.p0.character.tolist(), [melee.Character.FOX.value])
+      self.assertEqual(state.p1.character.tolist(), [melee.Character.FOX.value])
+    finally:
+      env.stop()
+
+  def test_max_frame_terminal_is_reported_separately(self):
+    env = self._sim_env(num_envs=2, length=128, max_frame_id=0)
+    try:
+      controllers = {
+          1: sim_env.neutral_controllers(2),
+          2: sim_env.neutral_controllers(2),
+      }
+      output = None
+      for _ in range(123):
+        output = env.step(controllers)
+      self.assertIsNotNone(output)
+      self.assertTrue(np.all(output.needs_reset))
+      terminal = env.last_step_info.terminal
+      self.assertTrue(np.all(terminal['done'] == 1))
+      self.assertTrue(np.all(terminal['max_frame_reached'] == 1))
+      self.assertTrue(np.all(terminal['match_ended'] == 0))
+    finally:
+      env.stop()
+
+  def test_packed_state_and_encoded_step(self):
+    env = self._sim_env(
+        num_envs=2,
+        players={
+            1: dolphin.AI(melee.Character.FOX),
+            2: dolphin.AI(melee.Character.FALCO),
+        },
+        length=8,
+    )
+    try:
+      state = env.current_game_batch(
+          needs_reset=np.ones(2, dtype=np.bool_))
+      self.assertEqual(state.needs_reset.shape, (4,))
+      self.assertEqual(state.game.p0.x.shape, (4,))
+      self.assertEqual(state.game.p0.character[:2].tolist(), [
+          melee.Character.FOX.value,
+          melee.Character.FOX.value,
+      ])
+      self.assertEqual(state.game.p0.character[2:].tolist(), [
+          melee.Character.FALCO.value,
+          melee.Character.FALCO.value,
+      ])
+      self.assertEqual(state.game.p1.character[:2].tolist(), [
+          melee.Character.FALCO.value,
+          melee.Character.FALCO.value,
+      ])
+      self.assertEqual(state.game.p1.character[2:].tolist(), [
+          melee.Character.FOX.value,
+          melee.Character.FOX.value,
+      ])
+
+      encoded = _neutral_encoded_controller(batch_size=4)
+      needs_reset = env.step_encoded(
+          encoded,
+          axis_spacing=32,
+          shoulder_spacing=4,
+      )
+      self.assertEqual(needs_reset.shape, (2,))
+      next_state = env.current_game_batch(needs_reset=needs_reset)
+      self.assertEqual(next_state.game.p0.x.shape, (4,))
+    finally:
+      env.stop()
+
+  def test_game_batch_matches_port_state_observation_conventions(self):
+    env = self._sim_env(
+        num_envs=3,
+        players={
+            1: dolphin.AI(melee.Character.FOX),
+            2: dolphin.AI(melee.Character.FALCO),
+        },
+        length=8,
+        stage=[
+            melee.Stage.FINAL_DESTINATION,
+            melee.Stage.BATTLEFIELD,
+            melee.Stage.YOSHIS_STORY,
+        ],
+    )
+    try:
+      controllers = {
+          1: sim_env.neutral_controllers(3),
+          2: sim_env.neutral_controllers(3),
+      }
+      controllers[1].main_stick.x[:] = [0.0, 0.25, 1.0]
+      controllers[1].buttons.A[:] = [True, False, True]
+      controllers[2].main_stick.x[:] = [0.125, 0.5, 0.875]
+      controllers[2].buttons.B[:] = [False, True, True]
+      env.step(controllers)
+
+      port_state = env.current_state()
+      game_batch = env.current_game_batch(
+          needs_reset=np.array([False, True, False], dtype=np.bool_))
+
+      port1 = port_state.gamestates[1]
+      port2 = port_state.gamestates[2]
+      np.testing.assert_array_equal(game_batch.game.p0.action[:3], port1.p0.action)
+      np.testing.assert_array_equal(game_batch.game.p1.action[:3], port1.p1.action)
+      np.testing.assert_array_equal(game_batch.game.p0.action[3:], port2.p0.action)
+      np.testing.assert_array_equal(game_batch.game.p1.action[3:], port2.p1.action)
+
+      np.testing.assert_array_equal(game_batch.game.stage[:3], port1.stage)
+      np.testing.assert_array_equal(game_batch.game.stage[3:], port2.stage)
+      np.testing.assert_allclose(game_batch.game.randall.x[:3], port1.randall.x)
+      np.testing.assert_allclose(game_batch.game.randall.x[3:], port2.randall.x)
+      np.testing.assert_allclose(game_batch.game.fod_platforms.left, 0.0)
+      np.testing.assert_allclose(game_batch.game.fod_platforms.right, 0.0)
+
+      np.testing.assert_allclose(
+          game_batch.game.p0.controller.main_stick.x,
+          [0.0, 0.25, 1.0, 0.125, 0.5, 0.875],
+      )
+      np.testing.assert_allclose(
+          game_batch.game.p1.controller.main_stick.x,
+          [0.125, 0.5, 0.875, 0.0, 0.25, 1.0],
+      )
+      np.testing.assert_array_equal(
+          game_batch.game.p0.controller.buttons.A,
+          [True, False, True, False, False, False],
+      )
+      np.testing.assert_array_equal(
+          game_batch.game.p1.controller.buttons.B,
+          [False, True, True, False, False, False],
+      )
+      np.testing.assert_array_equal(
+          game_batch.needs_reset,
+          [False, True, False, False, True, False],
+      )
+    finally:
+      env.stop()
+
+  def test_slot_adapter_matches_libmelee_visible_conventions(self):
+    slot = np.zeros(3, dtype=[
+        ('present', np.bool_),
+        ('stocks', np.uint8),
+        ('percent', np.float32),
+        ('facing', np.bool_),
+        ('pos_x', np.float32),
+        ('pos_y', np.float32),
+        ('action_id', np.uint16),
+        ('invulnerable', np.bool_),
+        ('char_id', np.uint8),
+        ('jumps_left', np.uint8),
+        ('shield_hp', np.float32),
+        ('on_ground', np.bool_),
+    ])
+    slot['present'] = True
+    slot['stocks'] = 4
+    slot['percent'] = [11.2, 11.8, 12.0]
+    slot['char_id'] = melee.Character.FOX.value
+    slot['jumps_left'] = [2, 2, 1]
+    slot['on_ground'] = [True, False, False]
+    slot['shield_hp'] = 60.0
+
+    player = observations.player_from_slot(slot, sim_env.neutral_controllers(3))
+
+    self.assertEqual(player.percent.tolist(), [11, 11, 12])
+    self.assertEqual(player.jumps_left.tolist(), [2, 1, 1])
+
+  def test_items_are_canonicalized_independent_of_backend_slot_order(self):
+    items = np.zeros((1, len(Items._fields)), dtype=[
+        ('exists', np.bool_),
+        ('type', np.uint16),
+        ('state', np.uint8),
+        ('pos_x', np.float32),
+        ('pos_y', np.float32),
+    ])
+    items[0, :4]['exists'] = [True, True, True, False]
+    items[0, :4]['type'] = [74, 54, 74, 0]
+    items[0, :4]['state'] = [4, 0, 5, 0]
+    items[0, :4]['pos_x'] = [-54.0, -32.0, 60.0, 0.0]
+    items[0, :4]['pos_y'] = [20.0, 40.0, 20.0, 0.0]
+
+    out = observations.items_from_frame(items)
+
+    self.assertEqual(out.item_0.type.tolist(), [74])
+    self.assertEqual(out.item_0.x.tolist(), [-54.0])
+    self.assertEqual(out.item_1.type.tolist(), [74])
+    self.assertEqual(out.item_1.x.tolist(), [60.0])
+    self.assertEqual(out.item_2.type.tolist(), [54])
+    self.assertEqual(out.item_2.x.tolist(), [-32.0])
+    self.assertFalse(out.item_3.exists[0])
+
+def _neutral_encoded_controller(batch_size: int):
+  shape = (int(batch_size),)
+  return Controller(
+      main_stick=Stick(
+          x=np.full(shape, 16, dtype=np.uint8),
+          y=np.full(shape, 16, dtype=np.uint8),
+      ),
+      c_stick=Stick(
+          x=np.full(shape, 16, dtype=np.uint8),
+          y=np.full(shape, 16, dtype=np.uint8),
+      ),
+      shoulder=np.zeros(shape, dtype=np.uint8),
+      buttons=Buttons(**{
+          name: np.zeros(shape, dtype=np.bool_)
+          for name in Buttons._fields
+      }),
+  )
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Adds a wrapper for RL training using a melee simulator (non-Dolphin) env type. Currently only a single process basic version. Also updates `scripts/run_evaluator.py` to support evaluating models via the sim environment.

Tested by training a fox ditto model on an imitation base with these settings:
``` 
num_envs: 200
rollout_length: 80
ppo.num_batches: 4
ppo.num_epochs: 1
agent.batch_steps: 8
learning_rate: 3e-5
kl_teacher_weight: 5e-3
reverse_kl_teacher_weight: 5e-3
max_mean_actor_kl: 1e-3
steps: 100


Tail from the final logged step:

  Step: 99
  rollout: 1.770, learner: 1.193, reset: 37.252, total: 3.003, fps: 21313.557, mps: 5.920, env_pop: 0.000, env_push: 0.002, agent_step: 0.011, agent_step_total: 0.022
  actor_kl: mean=1.23e-05 max=0.000858
  teacher_kl: 0.0558
  uev: 0.360

```
  
Then using `run_evaluator.py` to eval the trained model vs the base imitation:
```ko diff per minute: 0.3580645
completed games: total=100 wins=85 losses=15 ties=0 win_rate=0.850
game endings: stockouts=100 timeouts=0
game length: avg_frames=9969.7 avg_seconds=166.2
final stocks: player=1.51 opponent=0.17
stage BATTLEFIELD: total=16 wins=13 losses=3 ties=0 win_rate=0.812 avg_frames=8962.7
stage DREAMLAND: total=17 wins=13 losses=4 ties=0 win_rate=0.765 avg_frames=11537.0
stage FINAL_DESTINATION: total=16 wins=13 losses=3 ties=0 win_rate=0.812 avg_frames=10666.9
stage FOUNTAIN_OF_DREAMS: total=17 wins=16 losses=1 ties=0 win_rate=0.941 avg_frames=9366.8
stage POKEMON_STADIUM: total=17 wins=16 losses=1 ties=0 win_rate=0.941 avg_frames=10957.7
stage YOSHIS_STORY: total=17 wins=14 losses=3 ties=0 win_rate=0.824 avg_frames=8308.8
timings: {'env_pop': '0.001', 'env_push': '1.010', 'agent_pop': {1: '0.156', 2: '0.118'}, 'agent_step': {1: '9.966', 2: '10.018'}}
env_fps: 24312.00, player_fps: 48624.01, sps: 243.12
```

