### PR TITLE
Add an optimized sim rollout worker

### DIFF
--- a/scripts/run_evaluator.py
+++ b/scripts/run_evaluator.py
@@ -10,7 +10,8 @@ if __name__ == '__main__':
   from absl import app, flags
   import fancyflags as ff
 
-  from slippi_ai import eval_lib, dolphin, utils, evaluators, flag_utils, saving
+  from slippi_ai import (
+      eval_lib, dolphin, utils, evaluators, flag_utils, policies, saving)
 
   default_dolphin_config = dolphin.DolphinConfig(
       infinite_time=False,
@@ -138,12 +139,40 @@ if __name__ == '__main__':
     if NUM_GAMES.value and not SIM_ENVS.value:
       raise ValueError('--num_games currently requires --sim_envs.')
 
-    evaluator = evaluators.Evaluator(**evaluator_kwargs)
+    use_jax_sim_worker = (
+        SIM_ENVS.value and
+        len(agent_kwargs) == 2 and
+        all(
+            saving.get_platform(kwargs['state']['config']) is policies.Platform.JAX
+            for kwargs in agent_kwargs.values()
+        )
+    )
+    if use_jax_sim_worker:
+      from slippi_ai.sim_env import jax_rollout
+
+      train_opponent = SELF_PLAY.value
+      evaluator = jax_rollout.JaxSimRolloutWorker(
+          policy=saving.load_policy_from_state(agent_kwargs[1]['state']),
+          opponent_policy=(
+              None if train_opponent else
+              saving.load_policy_from_state(agent_kwargs[2]['state'])),
+          train_opponent=train_opponent,
+          agent_kwargs=agent_kwargs,
+          dolphin_kwargs=dolphin_kwargs,
+          num_envs=NUM_ENVS.value,
+          rollout_length=ROLLOUT_LENGTH.value,
+          batch_steps=NUM_AGENT_STEPS.value,
+          use_fake_envs=FAKE_ENVS.value,
+      )
+    else:
+      evaluator = evaluators.Evaluator(**evaluator_kwargs)
 
     with evaluator.run():
       # burnin
       batch_steps = NUM_AGENT_STEPS.value or 1
       burnin_steps = math.ceil(32 / batch_steps) * batch_steps
+      if use_jax_sim_worker:
+        burnin_steps = ROLLOUT_LENGTH.value
       evaluator.rollout(burnin_steps)
 
       if TF_PROFILE.value:
@@ -176,6 +205,11 @@ if __name__ == '__main__':
       with timer:
         while True:
           stats, metrics = evaluator.rollout(ROLLOUT_LENGTH.value, verbose=True)
+          if use_jax_sim_worker:
+            stats = {
+                port: evaluators.RolloutMetrics.from_trajectory(trajectory)
+                for port, trajectory in stats.items()
+            }
           total_steps += ROLLOUT_LENGTH.value
           for port, stat in stats.items():
             rewards[port] = rewards.get(port, 0) + stat.reward

--- a/slippi_ai/eval_lib.py
+++ b/slippi_ai/eval_lib.py
@@ -337,6 +337,22 @@ def get_name_code(state: dict, name: str) -> int:
     raise ValueError(f'Nametag must be one of {name_map.keys()}.')
   return name_map[name]
 
+
+def get_name_codes(
+    state: dict,
+    name: tp.Union[str, tp.Sequence[str]],
+    batch_size: tp.Optional[int] = None,
+) -> tp.Union[int, list[int]]:
+  if isinstance(name, str):
+    code = get_name_code(state, name)
+    if batch_size is None:
+      return code
+    return [code] * batch_size
+  if batch_size is not None and len(name) != batch_size:
+    raise ValueError(f'Nametag batch must have length batch_size={batch_size}')
+  return [get_name_code(state, n) for n in name]
+
+
 def get_agent_config(state: dict) -> tp.Optional[dict]:
   # TODO: unify self-train and train-two
   if 'rl_config' in state:  # self-train aka rl/run.py
@@ -395,10 +411,7 @@ def build_delayed_agent(
     # TODO: just pick from the name_map?
     raise ValueError('Must specify an agent name.')
 
-  if isinstance(name, str):
-    name_code = get_name_code(state, name)
-  else:
-    name_code = [get_name_code(state, n) for n in name]
+  name_code = get_name_codes(state, name)
 
   # Stick the observation_config into the agent for future use.
   observation_config = flag_utils.dataclass_from_dict(

--- a/slippi_ai/eval_lib.py
+++ b/slippi_ai/eval_lib.py
@@ -340,17 +340,16 @@ def get_name_code(state: dict, name: str) -> int:
 
 def get_name_codes(
     state: dict,
-    name: tp.Union[str, tp.Sequence[str]],
-    batch_size: tp.Optional[int] = None,
-) -> tp.Union[int, list[int]]:
+    name: str | tp.Sequence[str],
+    batch_size: int | None = None,
+) -> int | list[int]:
   if isinstance(name, str):
     code = get_name_code(state, name)
-    if batch_size is None:
-      return code
-    return [code] * batch_size
-  if batch_size is not None and len(name) != batch_size:
+    return code if batch_size is None else [code] * batch_size
+  codes = [get_name_code(state, n) for n in name]
+  if batch_size is not None and len(codes) != batch_size:
     raise ValueError(f'Nametag batch must have length batch_size={batch_size}')
-  return [get_name_code(state, n) for n in name]
+  return codes
 
 
 def get_agent_config(state: dict) -> tp.Optional[dict]:

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -71,8 +71,12 @@ class RolloutWorker:
   ):
     if isinstance(dolphin_kwargs, dict):
       dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(num_envs)]
+    elif num_envs != len(dolphin_kwargs):
+      raise ValueError(
+          f'num_envs={num_envs} does not match '
+          f'{len(dolphin_kwargs)} dolphin kwargs entries.')
     else:
-      assert num_envs == len(dolphin_kwargs)
+      dolphin_kwargs = list(dolphin_kwargs)
     self._dolphin_kwargs = dolphin_kwargs
 
     dolphin_kwargs_0 = dolphin_kwargs[0]
@@ -385,7 +389,6 @@ class RolloutMetrics(tp.NamedTuple):
   @classmethod
   def from_trajectory(cls, trajectory: Trajectory) -> tp.Self:
     return cls(reward=np.sum(trajectory.rewards))
-
 
 class Evaluator(RolloutWorker):
 

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -179,11 +179,6 @@ class RolloutWorker:
     if self._use_fake_envs:
       raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
 
-    characters = set(
-        player.character
-        for kwargs in self._dolphin_kwargs
-        for player in kwargs['players'].values()
-    )
     stages = [kwargs['stage'] for kwargs in self._dolphin_kwargs]
     if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
       stages = tuple(itertools.islice(
@@ -194,9 +189,8 @@ class RolloutWorker:
 
     return sim_env.SimBatchedEnvironment(
         num_envs=self._num_envs,
-        players=first_kwargs['players'],
+        players=[kwargs['players'] for kwargs in self._dolphin_kwargs],
         stage=stages,
-        character_pool=characters,
         max_frame_id=max_frame_id,
     )
 

--- a/slippi_ai/jax/agents.py
+++ b/slippi_ai/jax/agents.py
@@ -107,11 +107,7 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
       stacked_sample_outputs, (_, final_state) = scan_fn(
           rngs.fork(split=length), stacked_states_and_resets, (prev_action, initial_state))
 
-      sample_outputs = [
-          jax.tree.map(lambda t, i=i: t[i], stacked_sample_outputs)
-          for i in range(length)]
-
-      return sample_outputs, final_state
+      return stacked_sample_outputs, final_state
 
     self._multi_sample = jax_utils.cached_partial(multi_sample, policy, rngs)
 
@@ -158,6 +154,15 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
       needs_reset: agents.BoolArray,
   ) -> SampleOutputs[ControllerType]:
     """Doesn't take into account delay."""
+    sample_outputs = self.step_device(game, needs_reset)
+    return jax.copy_to_host_async(sample_outputs)
+
+  def step_device(
+      self,
+      game: Game,
+      needs_reset: agents.BoolArray,
+  ) -> SampleOutputs[ControllerType]:
+    """Sample an action and leave the output tree on device."""
     game = self._policy.network.encode_game(game)
     # Keep hidden state and prev_controller on device.
     sample_fn = self._jitted_sample if self._compile else self._sample
@@ -167,23 +172,35 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
     # Use donate_argnums?
     self._prev_controller = sample_outputs.controller_state
 
-    # Convert to numpy?
-    return jax.copy_to_host_async(sample_outputs)
+    return sample_outputs
 
   def multi_step(
       self,
       states: list[tuple[Game, agents.BoolArray]],
   ) -> list[SampleOutputs[ControllerType]]:
+    sample_outputs = self.multi_step_stacked_device(states)
+    sample_outputs = [
+        jax.tree.map(lambda t, i=i: t[i], sample_outputs)
+        for i in range(len(states))]
+    return jax.copy_to_host_async(sample_outputs)
+
+  def multi_step_stacked_device(
+      self,
+      states: list[tuple[Game, agents.BoolArray]],
+  ) -> SampleOutputs[ControllerType]:
+    # Fast rollout code consumes a whole time chunk at once. Returning the
+    # stacked device tree avoids per-frame Python objects and host copies; the
+    # compatibility `multi_step` wrapper above still provides the old list API.
     states_and_resets = [
         (self._policy.network.encode_game(game), needs_reset)
         for game, needs_reset in states
     ]
-
     # Keep hidden state and _prev_controller on device.
     multi_sample_fn = self._jitted_multi_sample if self._compile else self._multi_sample
     sample_outputs, self._hidden_state = multi_sample_fn(
         states_and_resets, self._name_code, self._prev_controller, self._hidden_state)
 
-    self._prev_controller = sample_outputs[-1].controller_state
+    self._prev_controller = jax.tree.map(
+        lambda t: t[-1], sample_outputs.controller_state)
 
-    return jax.copy_to_host_async(sample_outputs)
+    return sample_outputs

--- a/slippi_ai/jax/agents.py
+++ b/slippi_ai/jax/agents.py
@@ -85,7 +85,7 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
         name_code: jax.Array,
         prev_action: ControllerType,  # only for first step
         initial_state: policies.RecurrentState,
-    ) -> tuple[list[SampleOutputs[ControllerType]], policies.RecurrentState]:
+    ) -> tuple[SampleOutputs[ControllerType], policies.RecurrentState]:
 
       stacked_states_and_resets = jax.tree.map(
           lambda *xs: jnp.stack(xs, axis=0), *states_and_resets)
@@ -179,10 +179,11 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
       states: list[tuple[Game, agents.BoolArray]],
   ) -> list[SampleOutputs[ControllerType]]:
     sample_outputs = self.multi_step_stacked_device(states)
+    sample_outputs = jax.tree.map(np.asarray, sample_outputs)
     sample_outputs = [
         jax.tree.map(lambda t, i=i: t[i], sample_outputs)
         for i in range(len(states))]
-    return jax.copy_to_host_async(sample_outputs)
+    return sample_outputs
 
   def multi_step_stacked_device(
       self,

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -268,6 +268,10 @@ def reset_optimizer_steps(imitation_state: dict):
   for key in ['policy_optimizer', 'value_optimizer']:
     if key in imitation_state['state']:
       imitation_state['state'][key]['step'] = 0
+    else:
+      logging.warning(
+          'Imitation checkpoint is missing %s state; using a fresh optimizer.',
+          key)
 
 
 def run(config: Config):

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -438,6 +438,16 @@ def run(config: Config):
         inner_batch_size=config.actor.inner_batch_size,
     )
 
+  build_actor = lambda: evaluators.RolloutWorker(
+      agent_kwargs=agent_kwargs,
+      dolphin_kwargs=dolphin_kwargs,
+      env_kwargs=env_kwargs,
+      num_envs=config.actor.num_envs,
+      async_envs=config.actor.async_envs,
+      use_gpu=config.actor.gpu_inference,
+      use_fake_envs=config.actor.use_fake_envs,
+  )
+
   if config.actor.use_sim_envs:
     if config.actor.async_envs:
       raise ValueError('Sim envs are single-process; async_envs is not supported.')
@@ -466,16 +476,6 @@ def run(config: Config):
           batch_steps=config.agent.batch_steps,
           use_fake_envs=config.actor.use_fake_envs,
       )
-  else:
-    build_actor = lambda: evaluators.RolloutWorker(
-        agent_kwargs=agent_kwargs,
-        dolphin_kwargs=dolphin_kwargs,
-        env_kwargs=env_kwargs,
-        num_envs=config.actor.num_envs,
-        async_envs=config.actor.async_envs,
-        use_gpu=config.actor.gpu_inference,
-        use_fake_envs=config.actor.use_fake_envs,
-    )
 
   learner_manager = LearnerManager(
       config=config,
@@ -541,12 +541,7 @@ def run(config: Config):
         mps=mps,
     )
     actor_timing = metrics['actor'].pop('timing')
-    env_timing_keys = (
-        ['state_copy', 'env_step']
-        if config.actor.use_sim_envs else
-        ['env_pop', 'env_push']
-    )
-    for key in env_timing_keys:
+    for key in ['env_pop', 'env_push']:
       timings[key] = actor_timing[key]
 
     agent_keys = ['agent_step']

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -439,14 +439,10 @@ def run(config: Config):
     )
 
   if config.actor.use_sim_envs:
-    if config.actor.use_fake_envs:
-      raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
     if config.actor.async_envs:
       raise ValueError('Sim envs are single-process; async_envs is not supported.')
     if config.opponent.type == OpponentType.CPU:
       raise ValueError('Sim env only supports AI-vs-AI opponents.')
-    if not config.opponent.should_train():
-      raise ValueError('JAX sim RL currently requires self-play training.')
     if config.agent.batch_steps > policy.delay:
       raise ValueError(
           f'agent.batch_steps={config.agent.batch_steps} exceeds policy delay '
@@ -455,12 +451,20 @@ def run(config: Config):
       raise ValueError('agent.batch_steps must divide rollout_length for sim RL.')
 
     def build_actor():
+      opponent_policy = None
+      train_opponent = config.opponent.should_train()
+      if not train_opponent:
+        opponent_policy = jax_saving.load_policy_from_state(
+            agent_kwargs[ENEMY_PORT]['state'])
       return jax_rollout.JaxSimRolloutWorker(
           policy=learner.policy,
+          opponent_policy=opponent_policy,
+          train_opponent=train_opponent,
           agent_kwargs=agent_kwargs,
           dolphin_kwargs=dolphin_kwargs,
           num_envs=config.actor.num_envs,
           batch_steps=config.agent.batch_steps,
+          use_fake_envs=config.actor.use_fake_envs,
       )
   else:
     build_actor = lambda: evaluators.RolloutWorker(

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -24,6 +24,7 @@ from slippi_ai import (
 from slippi_ai.jax import saving as jax_saving
 from slippi_ai.jax import train_lib as train_lib
 from slippi_ai.jax.rl import learner as learner_lib
+from slippi_ai.sim_env import jax_rollout
 from slippi_ai.types import Game
 
 field = lambda f: dataclasses.field(default_factory=f)
@@ -265,7 +266,8 @@ def concise_name(name: str) -> str:
 
 def reset_optimizer_steps(imitation_state: dict):
   for key in ['policy_optimizer', 'value_optimizer']:
-    imitation_state['state'][key]['step'] = 0
+    if key in imitation_state['state']:
+      imitation_state['state'][key]['step'] = 0
 
 
 def run(config: Config):
@@ -443,17 +445,33 @@ def run(config: Config):
       raise ValueError('Sim envs are single-process; async_envs is not supported.')
     if config.opponent.type == OpponentType.CPU:
       raise ValueError('Sim env only supports AI-vs-AI opponents.')
+    if not config.opponent.should_train():
+      raise ValueError('JAX sim RL currently requires self-play training.')
+    if config.agent.batch_steps > policy.delay:
+      raise ValueError(
+          f'agent.batch_steps={config.agent.batch_steps} exceeds policy delay '
+          f'{policy.delay} for sim RL.')
+    if config.actor.rollout_length % max(1, config.agent.batch_steps):
+      raise ValueError('agent.batch_steps must divide rollout_length for sim RL.')
 
-  build_actor = lambda: evaluators.RolloutWorker(
-      agent_kwargs=agent_kwargs,
-      dolphin_kwargs=dolphin_kwargs,
-      env_kwargs=env_kwargs,
-      num_envs=config.actor.num_envs,
-      async_envs=config.actor.async_envs,
-      use_gpu=config.actor.gpu_inference,
-      use_fake_envs=config.actor.use_fake_envs,
-      use_sim_envs=config.actor.use_sim_envs,
-  )
+    def build_actor():
+      return jax_rollout.JaxSimRolloutWorker(
+          policy=learner.policy,
+          agent_kwargs=agent_kwargs,
+          dolphin_kwargs=dolphin_kwargs,
+          num_envs=config.actor.num_envs,
+          batch_steps=config.agent.batch_steps,
+      )
+  else:
+    build_actor = lambda: evaluators.RolloutWorker(
+        agent_kwargs=agent_kwargs,
+        dolphin_kwargs=dolphin_kwargs,
+        env_kwargs=env_kwargs,
+        num_envs=config.actor.num_envs,
+        async_envs=config.actor.async_envs,
+        use_gpu=config.actor.gpu_inference,
+        use_fake_envs=config.actor.use_fake_envs,
+    )
 
   learner_manager = LearnerManager(
       config=config,
@@ -519,7 +537,12 @@ def run(config: Config):
         mps=mps,
     )
     actor_timing = metrics['actor'].pop('timing')
-    for key in ['env_pop', 'env_push']:
+    env_timing_keys = (
+        ['state_copy', 'env_step']
+        if config.actor.use_sim_envs else
+        ['env_pop', 'env_push']
+    )
+    for key in env_timing_keys:
       timings[key] = actor_timing[key]
 
     agent_keys = ['agent_step']

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -477,6 +477,7 @@ def run(config: Config):
           agent_kwargs=agent_kwargs,
           dolphin_kwargs=dolphin_kwargs,
           num_envs=config.actor.num_envs,
+          rollout_length=config.actor.rollout_length,
           batch_steps=config.agent.batch_steps,
           use_fake_envs=config.actor.use_fake_envs,
       )

--- a/slippi_ai/reward.py
+++ b/slippi_ai/reward.py
@@ -147,9 +147,7 @@ def compute_rewards(
   def player_reward(player: Player, opponent: Player):
     reward = compute_base_reward(player)
 
-    if nana_ratio != 0:
-      if player.nana == ():
-        raise ValueError("Nana data is required for nana_ratio != 0")
+    if nana_ratio != 0 and player.nana != ():
       nana_reward = nana_ratio * compute_base_reward(player.nana)
       nana_reward = np.where(player.nana.exists[1:], nana_reward, 0)
       reward += nana_reward

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -76,6 +76,7 @@ class SimStepInfo(tp.NamedTuple):
   step_t: int
 
 
+PlayerConfigs = tp.Mapping[int, dolphin.Player]
 CharacterPool = str | tp.Sequence[melee.Character | str | int]
 
 
@@ -91,7 +92,7 @@ class SimBatchedEnvironment:
   def __init__(
       self,
       num_envs: int,
-      players: tp.Mapping[int, dolphin.Player] | None = None,
+      players: PlayerConfigs | tp.Sequence[PlayerConfigs] | None = None,
       *,
       frame_buffer_length: int = 128,
       stage: melee.Stage | tp.Sequence[melee.Stage] = melee.Stage.FINAL_DESTINATION,
@@ -109,15 +110,22 @@ class SimBatchedEnvironment:
     # The sim adapter currently exposes the singles shape used by the policy:
     # port 1 and port 2, no teams, one controlled character per port.
     if players is None:
-      self._players = {
+      default_players = {
           1: dolphin.AI(melee.Character.FOX),
           2: dolphin.AI(melee.Character.FOX),
       }
+      self._players_by_env = (default_players,) * self._num_envs
+    elif isinstance(players, collections.abc.Mapping):
+      self._players_by_env = (players,) * self._num_envs
     else:
-      self._players = players
+      self._players_by_env = tuple(players)
+      if len(self._players_by_env) != self._num_envs:
+        raise ValueError(f'players sequence must have length num_envs={self._num_envs}')
+    self._players = self._players_by_env[0]
     self._ports = tuple(sorted(self._players))
-    if self._ports != _SUPPORTED_PORTS:
-      raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
+    for player_map in self._players_by_env:
+      if tuple(sorted(player_map)) != _SUPPORTED_PORTS:
+        raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
 
     # `stage` can be one value for every lane or an explicit per-env list.
     if isinstance(stage, melee.Stage):
@@ -131,17 +139,18 @@ class SimBatchedEnvironment:
         raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
     self._stage_by_env = np.asarray(stages, dtype=object)
 
-    # Default to the explicit player matchup everywhere. If a pool is supplied,
-    # cycle lanes through the ordered singles matchup matrix. Resets keep each
-    # lane's initial matchup until we intentionally add randomized reset-time
-    # assignment later.
+    # Default to the explicit player matchup for each lane. If a pool is
+    # supplied, cycle lanes through the ordered singles matchup matrix. Resets
+    # keep each lane's initial matchup until we intentionally add randomized
+    # reset-time assignment later.
     if character_pool is None:
-      character_assignments = (
+      character_assignments = tuple(
           (
-              _coerce_character(self._players[1].character),
-              _coerce_character(self._players[2].character),
-          ),
-      ) * self._num_envs
+              _coerce_character(player_map[1].character),
+              _coerce_character(player_map[2].character),
+          )
+          for player_map in self._players_by_env
+      )
     else:
       if isinstance(character_pool, str):
         characters = tuple(

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -98,10 +98,12 @@ class SimBatchedEnvironment:
       character_pool: CharacterPool | None = None,
       max_frame_id: int = -1,
       data_dir: str | None = None,
+      fake: bool = False,
   ):
     self._num_envs = int(num_envs)
     self._frame_buffer_length = int(frame_buffer_length)
     self._max_frame_id = int(max_frame_id)
+    self._fake = fake
     self.num_steps = 1
 
     # The sim adapter currently exposes the singles shape used by the policy:
@@ -314,6 +316,8 @@ class SimBatchedEnvironment:
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )
+    if self._fake:
+      return np.zeros(self._num_envs, dtype=np.bool_)
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
@@ -379,6 +383,8 @@ class SimBatchedEnvironment:
           slice(None),
           slice(None),
       )
+    if self._fake:
+      return self.current_state(needs_reset=np.zeros(self._num_envs, dtype=np.bool_))
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -64,7 +64,7 @@ class JaxSimRolloutWorker:
     agent1_kwargs = agent_kwargs[1]
     agent2_kwargs = agent_kwargs[2]
 
-    should_compile = agent1_kwargs.get('compile', True)
+    should_compile = agent1_kwargs['compile']
     state = agent1_kwargs['state']
     name_code_by_port = {
         port: np.asarray(
@@ -101,7 +101,7 @@ class JaxSimRolloutWorker:
       self._opponent_actor = opponent_policy.build_agent(
           batch_size=self._num_envs,
           name_code=name_code_by_port[2],
-          compile=should_compile,
+          compile=agent2_kwargs['compile'],
           pack_args=True,
       )
 
@@ -115,13 +115,21 @@ class JaxSimRolloutWorker:
           itertools.cycle(sim_env.SUPPORTED_STAGES),
           self._num_envs,
       ))
+    character_pairs = [
+        tuple(kwargs['players'][port].character for port in self.ports)
+        for kwargs in dolphin_kwargs
+    ]
+    if any(pair != character_pairs[0] for pair in character_pairs):
+      raise ValueError(
+          'JAX sim rollout currently requires one character matchup per batch.')
+
     controller_config = state['config']['embed']['controller']
     other_config = agent2_kwargs['state']['config']['embed']['controller']
     if other_config != controller_config:
       raise ValueError('JAX sim rollout requires matching controller configs.')
-    if controller_config.get('type', 'default') != 'default':
+    if controller_config['type'] != 'default':
       raise ValueError('sim env only supports the default controller embedding')
-    controller_config = controller_config.get('default', controller_config)
+    controller_config = controller_config['default']
     self._controller_spacing = (
         int(controller_config['axis_spacing']),
         int(controller_config['shoulder_spacing']),
@@ -213,6 +221,8 @@ class JaxSimRolloutWorker:
     # Step the sim immediately with already-delayed controller inputs, while
     # collecting a chunk of observations for one fused JAX actor call.
     for chunk_start in range(0, num_steps, self._batch_steps):
+      # `chunk_len` is normally `_batch_steps`; it is shorter only for a final
+      # partial chunk when num_steps is not divisible by batch_steps.
       chunk_len = min(self._batch_steps, num_steps - chunk_start)
       chunk_inputs = []
       chunk_reset_masks = []
@@ -347,7 +357,7 @@ class JaxSimRolloutWorker:
     }
 
   def _build_env_if_needed(self, num_steps: int):
-    frame_buffer_length = int(num_steps) + self.actor._policy.delay + 2
+    frame_buffer_length = num_steps + self.actor._policy.delay + 2
     if self._env is not None:
       if self._frame_buffer_length >= frame_buffer_length:
         return
@@ -371,9 +381,9 @@ class _TrajectoryStateBuffer(tp.NamedTuple):
   """Time-major storage for T+1 policy observations.
 
   `current_game_batch()` reuses one mutable Game tree, while the learner needs
-  the whole rollout after the sim has advanced. This buffer copies each frame's
-  leaves into pre-sliced time slots without rebuilding a new Game object per
-  frame.
+  the whole rollout after the sim has advanced. `slots` are NumPy views into the
+  time-major `states` tree, so copying into a slot writes directly into the
+  corresponding frame of the final trajectory buffer.
   """
 
   states: Game
@@ -388,14 +398,14 @@ def _make_trajectory_state_buffer(
 ) -> _TrajectoryStateBuffer:
   states = utils.map_single_structure(
       lambda leaf: np.empty(
-          (int(rollout_length) + 1,) + np.asarray(leaf).shape,
+          (rollout_length + 1,) + np.asarray(leaf).shape,
           dtype=np.asarray(leaf).dtype,
       ),
       source_game,
   )
   slots = [
       utils.map_single_structure(lambda leaf, i=i: leaf[i], states)
-      for i in range(int(rollout_length) + 1)
+      for i in range(rollout_length + 1)
   ]
   return _TrajectoryStateBuffer(
       states=states,
@@ -407,7 +417,7 @@ def _make_trajectory_state_buffer(
 
 def _copy_state_slot(state_buffer: _TrajectoryStateBuffer, index: int):
   for dst, src in zip(
-      state_buffer.slot_leaves[int(index)],
+      state_buffer.slot_leaves[index],
       state_buffer.source_leaves,
   ):
     dst[...] = src
@@ -424,7 +434,7 @@ def _trajectory_slice(
     name_code: np.ndarray,
     batch_slice: slice,
 ) -> Trajectory:
-  batch_size = int(batch_slice.stop) - int(batch_slice.start)
+  batch_size = batch_slice.stop - batch_slice.start
   return Trajectory(
       states=utils.map_single_structure(
           lambda x: np.asarray(x[:, batch_slice]).copy(), states),
@@ -447,7 +457,10 @@ def _batch_actions(actions: list[SampleOutputs]) -> SampleOutputs:
   return jax.tree.map(lambda *xs: np.stack(xs, axis=0), *actions)
 
 
-def _sample_chunk(actor, chunk_inputs):
+def _sample_chunk(
+    actor: tp.Any,
+    chunk_inputs: list[tuple[Game, np.ndarray]],
+) -> SampleOutputs:
   if len(chunk_inputs) == 1:
     return jax.tree.map(
         lambda x: x[None],

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -138,7 +138,7 @@ class JaxSimRolloutWorker:
         max_frame_id=(
             -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
         fake=use_fake_envs,
-        frame_buffer_length=self._rollout_length + self.actor._policy.delay + 2,
+        frame_buffer_length=self._rollout_length + 1,
     )
 
     self._env = self._build_env()
@@ -448,11 +448,6 @@ def _sample_chunk(
     actor: tp.Any,
     chunk_inputs: list[tuple[Game, np.ndarray]],
 ) -> SampleOutputs:
-  if len(chunk_inputs) == 1:
-    return jax.tree.map(
-        lambda x: x[None],
-        actor.step_device(chunk_inputs[0][0], chunk_inputs[0][1]),
-    )
   return actor.multi_step_stacked_device(chunk_inputs)
 
 

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -1,10 +1,11 @@
 """JAX rollout assembly for single-process melee-sim-light envs.
 
-The generic evaluator path builds libmelee-shaped Python objects once per port
-per frame. This worker uses `SimBatchedEnvironment.current_game_batch()` and
-`step_encoded()` instead: one reusable observation tree is filled from native
-sim buffers, JAX samples both port perspectives, and the resulting trajectory is
-split back into the port entries expected by the learner.
+The generic evaluator path builds slippi-ai Game/controller Python objects once
+per port per frame. This worker uses
+`SimBatchedEnvironment.current_game_batch()` and `step_encoded()` instead: one
+reusable observation tree is filled from native sim buffers, JAX samples both
+port perspectives, and the resulting trajectory is split back into the port
+entries expected by the learner.
 """
 
 import collections
@@ -13,7 +14,6 @@ import time
 import typing as tp
 
 import jax
-import jax.numpy as jnp
 import melee
 import numpy as np
 
@@ -277,22 +277,19 @@ class JaxSimRolloutWorker:
         ]
         main_start = time.perf_counter()
         main_outputs = _sample_chunk(self.actor, main_inputs)
+        main_outputs = jax.tree.map(np.asarray, main_outputs)
         timings['agent_step_1'] += time.perf_counter() - main_start
 
         opponent_start = time.perf_counter()
         opponent_outputs = _sample_chunk(self._opponent_actor, opponent_inputs)
+        opponent_outputs = jax.tree.map(np.asarray, opponent_outputs)
         timings['agent_step_2'] += time.perf_counter() - opponent_start
 
         chunk_outputs = jax.tree.map(
-            lambda a, b: jnp.concatenate([a, b], axis=1),
+            lambda a, b: np.concatenate([a, b], axis=1),
             main_outputs,
             opponent_outputs,
         )
-        materialize_start = time.perf_counter()
-        chunk_outputs = jax.tree.map(np.asarray, chunk_outputs)
-        elapsed = time.perf_counter() - materialize_start
-        timings['agent_step_1'] += elapsed / 2.0
-        timings['agent_step_2'] += elapsed / 2.0
       _replay_delayed_controller_queue(
           self._delayed_controller_queue,
           controller_queue_start,
@@ -429,7 +426,8 @@ def _trajectory_slice(
 ) -> Trajectory:
   batch_size = int(batch_slice.stop) - int(batch_slice.start)
   return Trajectory(
-      states=utils.map_single_structure(lambda x: x[:, batch_slice], states),
+      states=utils.map_single_structure(
+          lambda x: np.asarray(x[:, batch_slice]).copy(), states),
       name=np.broadcast_to(
           name_code[batch_slice],
           (is_resetting.shape[0], batch_size),

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -1,0 +1,435 @@
+"""JAX rollout assembly for single-process melee-sim-light envs.
+
+The generic evaluator path builds libmelee-shaped Python objects once per port
+per frame. This worker uses `SimBatchedEnvironment.current_game_batch()` and
+`step_encoded()` instead: one reusable observation tree is filled from native
+sim buffers, one JAX actor samples both port perspectives, and the resulting
+trajectory is split back into the two port entries expected by the learner.
+"""
+
+import collections
+import itertools
+import time
+import typing as tp
+
+import jax
+import melee
+import numpy as np
+
+from slippi_ai import eval_lib
+from slippi_ai import reward
+from slippi_ai import sim_env
+from slippi_ai import utils
+from slippi_ai.controller_heads import SampleOutputs
+from slippi_ai.data import NAME_DTYPE
+from slippi_ai.evaluators import Port, Timings, Trajectory
+from slippi_ai.jax import policies
+from slippi_ai.types import Game
+
+
+class JaxSimRolloutWorker:
+  """RolloutWorker-compatible adapter for JAX self-play on one sim batch."""
+
+  ports: tuple[Port, Port] = (1, 2)
+
+  def __init__(
+      self,
+      *,
+      policy: policies.Policy,
+      agent_kwargs: tp.Mapping[int, dict],
+      dolphin_kwargs: tp.Union[dict, tp.Sequence[dict]],
+      num_envs: int,
+      batch_steps: int = 1,
+  ):
+    self._num_envs = int(num_envs)
+    if isinstance(dolphin_kwargs, dict):
+      dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(self._num_envs)]
+    elif self._num_envs != len(dolphin_kwargs):
+      raise ValueError(
+          f'num_envs={self._num_envs} does not match '
+          f'{len(dolphin_kwargs)} dolphin kwargs entries.')
+    else:
+      dolphin_kwargs = list(dolphin_kwargs)
+
+    if set(agent_kwargs) != set(self.ports):
+      raise ValueError(
+          f'JAX sim rollout requires agent kwargs for ports {self.ports}.')
+    agent1_kwargs = agent_kwargs[1]
+    agent2_kwargs = agent_kwargs[2]
+
+    # Build one batched actor for both player perspectives. The learner sends
+    # one policy state, and this actor samples port-1 lanes followed by port-2
+    # lanes from the same current policy.
+    should_compile = agent1_kwargs.get('compile', True)
+    if agent2_kwargs.get('compile', True) != should_compile:
+      raise ValueError('JAX sim rollout requires matching agent compile config.')
+    state = agent1_kwargs['state']
+    name_code = np.asarray([
+        code
+        for kwargs in (agent1_kwargs, agent2_kwargs)
+        for code in eval_lib.get_name_codes(
+            kwargs['state'],
+            kwargs['name'],
+            batch_size=self._num_envs,
+        )
+    ], dtype=NAME_DTYPE)
+
+    self.actor = policy.build_agent(
+        batch_size=self._num_envs * 2,
+        name_code=name_code,
+        compile=should_compile,
+        pack_args=True,
+    )
+
+    # Translate the Dolphin-style environment config into the smaller sim env
+    # config. The sim path still accepts the same high-level launch config as
+    # the generic rollout worker.
+    dolphin_kwargs_0 = dolphin_kwargs[0]
+    stages = [kwargs['stage'] for kwargs in dolphin_kwargs]
+    if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
+      stages = list(itertools.islice(
+          itertools.cycle(sim_env.SUPPORTED_STAGES),
+          self._num_envs,
+      ))
+    controller_config = state['config']['embed']['controller']
+    other_config = agent2_kwargs['state']['config']['embed']['controller']
+    if other_config != controller_config:
+      raise ValueError('JAX sim rollout requires matching controller configs.')
+    if controller_config.get('type', 'default') != 'default':
+      raise ValueError('sim env only supports the default controller embedding')
+    controller_config = controller_config.get('default', controller_config)
+    self._controller_spacing = (
+        int(controller_config['axis_spacing']),
+        int(controller_config['shoulder_spacing']),
+    )
+    self._name_code = name_code
+    self._batch_steps = max(1, int(batch_steps))
+    self._frame_buffer_length = 0
+    self._env_kwargs = dict(
+        num_envs=self._num_envs,
+        players=dolphin_kwargs_0['players'],
+        stage=stages,
+        character_pool=None,
+        max_frame_id=(
+            -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
+    )
+
+    # The sim env is created lazily from rollout(num_steps), matching the
+    # generic RolloutWorker API where rollout length is not constructor state.
+    self._env = None
+    self._needs_reset = None
+    self._state_buffer = None
+    self._reset_buffer = None
+    self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
+        [self._num_envs * 2])
+    self._reset_delay_queues()
+
+  def _reset_delay_queues(self):
+    # Keep one controller in the queue even when policy delay is 0; then the
+    # same queue update path covers both immediate and delayed control.
+    self._delayed_controller_queue = collections.deque(
+        [_copy_to_numpy_tree(self._dummy_outputs.controller_state)
+         for _ in range(self.actor._policy.delay + 1)])
+    self._delayed_outputs_queue = collections.deque(
+        [_copy_to_numpy_tree(self._dummy_outputs)
+         for _ in range(self.actor._policy.delay + 1)])
+
+  def start(self):
+    pass
+
+  def stop(self):
+    if self._env is not None:
+      self._env.stop()
+    self._env = None
+    self._needs_reset = None
+    self._state_buffer = None
+    self._reset_buffer = None
+    self._frame_buffer_length = 0
+
+  def reset_env(self):
+    self.stop()
+    self._reset_delay_queues()
+
+  def update_variables(self, updates):
+    if not updates:
+      raise ValueError('JAX sim rollout update_variables requires policy values.')
+    unknown_ports = set(updates) - set(self.ports)
+    if unknown_ports:
+      raise ValueError(f'Unexpected policy update ports: {unknown_ports}')
+    # This worker is for same-policy self-play: one actor controls both ports,
+    # so any provided port update is the same learner policy state.
+    self.actor._policy.set_state(updates.get(1, updates.get(2)))
+
+  def rollout(
+      self,
+      num_steps: int,
+      verbose: bool = False,
+  ) -> tuple[tp.Mapping[Port, Trajectory], Timings]:
+    del verbose
+    timings: dict[str, float] = collections.defaultdict(float)
+    num_steps = int(num_steps)
+    self._build_env_if_needed(num_steps)
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    if self._state_buffer is None:
+      self._state_buffer = _make_trajectory_state_buffer(
+          game_batch.game, num_steps)
+      self._reset_buffer = np.empty(
+          (num_steps + 1, self._num_envs * 2), dtype=np.bool_)
+    state_buffer = self._state_buffer
+    reset_buffer = self._reset_buffer
+    trajectory_actions = []
+    initial_state = self.actor.hidden_state()
+
+    # Step the sim immediately with already-delayed controller inputs, while
+    # collecting a chunk of observations for one fused JAX actor call.
+    for chunk_start in range(0, num_steps, self._batch_steps):
+      chunk_len = min(self._batch_steps, num_steps - chunk_start)
+      chunk_inputs = []
+      chunk_reset_masks = []
+      controller_queue_start = list(self._delayed_controller_queue)
+
+      for local_t in range(chunk_len):
+        t = chunk_start + local_t
+        copy_start = time.perf_counter()
+        _copy_state_slot(state_buffer, t)
+        reset_buffer[t] = game_batch.needs_reset
+        timings['state_copy'] += time.perf_counter() - copy_start
+
+        reset_mask = game_batch.needs_reset
+        chunk_inputs.append((state_buffer.slots[t], reset_mask))
+        # Keep the per-frame reset mask stable while later sim steps reuse the
+        # game_batch buffers and while the chunk replay rebuilds delayed inputs.
+        chunk_reset_masks.append(reset_mask.copy())
+        if np.any(reset_mask):
+          _reset_delayed_controller_queue(
+              self._delayed_controller_queue,
+              self._dummy_outputs.controller_state,
+              reset_mask,
+          )
+
+        delayed_controller = self._delayed_controller_queue.popleft()
+        trajectory_actions.append(self._delayed_outputs_queue.popleft())
+
+        env_start = time.perf_counter()
+        self._needs_reset = self._env.step_encoded(
+            delayed_controller,
+            axis_spacing=self._controller_spacing[0],
+            shoulder_spacing=self._controller_spacing[1],
+        )
+        game_batch = self._env.current_game_batch(self._needs_reset)
+        timings['env_step'] += time.perf_counter() - env_start
+
+      step_start = time.perf_counter()
+      if chunk_len == 1:
+        chunk_outputs = jax.tree.map(
+            lambda x: x[None],
+            self.actor.step_device(chunk_inputs[0][0], chunk_inputs[0][1]),
+        )
+      else:
+        chunk_outputs = self.actor.multi_step_stacked_device(chunk_inputs)
+      timings['agent_step'] += time.perf_counter() - step_start
+      _replay_delayed_controller_queue(
+          self._delayed_controller_queue,
+          controller_queue_start,
+          chunk_outputs,
+          chunk_reset_masks,
+          self._dummy_outputs.controller_state,
+      )
+      for index in range(chunk_len):
+        self._delayed_outputs_queue.append(
+            jax.tree.map(lambda x, i=index: x[i], chunk_outputs))
+
+    # Capture the T+1 terminal observation and assemble the learner trajectory
+    # trees expected by the existing PPO path.
+    copy_start = time.perf_counter()
+    _copy_state_slot(state_buffer, num_steps)
+    reset_buffer[num_steps] = game_batch.needs_reset
+    trajectory_actions.append(self._delayed_outputs_queue[0])
+    timings['state_copy'] += time.perf_counter() - copy_start
+
+    build_start = time.perf_counter()
+    time_major_states = state_buffer.states
+    encoded_states = self.actor._policy.network.encode_game(time_major_states)
+    rewards = reward.compute_rewards(time_major_states)
+    batched_actions = _batch_actions(trajectory_actions)
+    delayed_actions = list(self._delayed_outputs_queue)[1:]
+    timings['trajectory_build'] = time.perf_counter() - build_start
+
+    trajectories = {}
+    for port, batch_slice in (
+        (1, slice(0, self._num_envs)),
+        (2, slice(self._num_envs, self._num_envs * 2)),
+    ):
+      trajectories[port] = _trajectory_slice(
+          states=encoded_states,
+          actions=batched_actions,
+          rewards=rewards,
+          is_resetting=reset_buffer,
+          initial_state=initial_state,
+          delayed_actions=delayed_actions,
+          name_code=self._name_code,
+          batch_slice=batch_slice,
+      )
+    timing = {
+        'state_copy': timings['state_copy'] / max(num_steps, 1),
+        'env_step': timings['env_step'] / max(num_steps, 1),
+        'agent_step': {
+            port: timings['agent_step'] / max(num_steps, 1)
+            for port in self.ports
+        },
+        'trajectory_build': timings['trajectory_build'],
+    }
+    return trajectories, {
+        'timing': timing,
+        'unexpected_reset': reset_buffer[1:, :self._num_envs].copy(),
+        'completed_games': self._env.pop_completed_games(),
+    }
+
+  def _build_env_if_needed(self, num_steps: int):
+    frame_buffer_length = int(num_steps) + self.actor._policy.delay + 2
+    if self._env is not None:
+      if self._frame_buffer_length >= frame_buffer_length:
+        return
+      self._env.stop()
+      self._env = None
+      self._needs_reset = None
+      self._state_buffer = None
+      self._reset_buffer = None
+      self._frame_buffer_length = 0
+
+    self._env = sim_env.SimBatchedEnvironment(
+        **self._env_kwargs,
+        frame_buffer_length=frame_buffer_length,
+    )
+    self._frame_buffer_length = frame_buffer_length
+    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
+    self._reset_delay_queues()
+
+
+class _TrajectoryStateBuffer(tp.NamedTuple):
+  """Time-major storage for T+1 policy observations.
+
+  `current_game_batch()` reuses one mutable Game tree, while the learner needs
+  the whole rollout after the sim has advanced. This buffer copies each frame's
+  leaves into pre-sliced time slots without rebuilding a new Game object per
+  frame.
+  """
+
+  states: Game
+  slots: list[Game]
+  slot_leaves: list[tuple]
+  source_leaves: tuple
+
+
+def _make_trajectory_state_buffer(
+    source_game: Game,
+    rollout_length: int,
+) -> _TrajectoryStateBuffer:
+  states = utils.map_single_structure(
+      lambda leaf: np.empty(
+          (int(rollout_length) + 1,) + np.asarray(leaf).shape,
+          dtype=np.asarray(leaf).dtype,
+      ),
+      source_game,
+  )
+  slots = [
+      utils.map_single_structure(lambda leaf, i=i: leaf[i], states)
+      for i in range(int(rollout_length) + 1)
+  ]
+  return _TrajectoryStateBuffer(
+      states=states,
+      slots=slots,
+      slot_leaves=[tuple(jax.tree.leaves(slot)) for slot in slots],
+      source_leaves=tuple(jax.tree.leaves(source_game)),
+  )
+
+
+def _copy_state_slot(state_buffer: _TrajectoryStateBuffer, index: int):
+  for dst, src in zip(
+      state_buffer.slot_leaves[int(index)],
+      state_buffer.source_leaves,
+  ):
+    dst[...] = src
+
+
+def _trajectory_slice(
+    *,
+    states: Game,
+    actions: SampleOutputs,
+    rewards: np.ndarray,
+    is_resetting: np.ndarray,
+    initial_state,
+    delayed_actions: list[SampleOutputs],
+    name_code: np.ndarray,
+    batch_slice: slice,
+) -> Trajectory:
+  batch_size = int(batch_slice.stop) - int(batch_slice.start)
+  return Trajectory(
+      states=utils.map_single_structure(lambda x: x[:, batch_slice], states),
+      name=np.broadcast_to(
+          name_code[batch_slice],
+          (is_resetting.shape[0], batch_size),
+      ).copy(),
+      actions=utils.map_single_structure(lambda x: x[:, batch_slice], actions),
+      rewards=rewards[:, batch_slice],
+      is_resetting=is_resetting[:, batch_slice].copy(),
+      initial_state=utils.map_single_structure(
+          lambda x: x[batch_slice], initial_state),
+      delayed_actions=[
+          utils.map_single_structure(lambda x: x[batch_slice], action)
+          for action in delayed_actions
+      ],
+  )
+
+
+def _batch_actions(actions: list[SampleOutputs]) -> SampleOutputs:
+  return jax.tree.map(lambda *xs: np.stack(xs, axis=0), *actions)
+
+
+def _replay_delayed_controller_queue(
+    queue: collections.deque,
+    queue_start: list,
+    sample_outputs: SampleOutputs,
+    reset_masks: list[np.ndarray],
+    neutral_controller,
+):
+  # The sim consumes controller inputs after policy delay, so while collecting a
+  # chunk we have to step with the queue as it existed at chunk start. Once the
+  # actor returns the whole time-stacked chunk, replay those sampled controllers
+  # into the delay queue in order, applying neutral reset sentinels lane-wise.
+  queue.clear()
+  queue.extend(queue_start)
+  for index, reset_mask in enumerate(reset_masks):
+    if np.any(reset_mask):
+      _reset_delayed_controller_queue(queue, neutral_controller, reset_mask)
+    controller = jax.tree.map(
+        lambda x: np.asarray(x[int(index)]).copy(),
+        sample_outputs.controller_state,
+    )
+    queue.append(controller)
+    queue.popleft()
+
+
+def _copy_to_numpy_tree(value):
+  return utils.map_single_structure(lambda x: np.asarray(x).copy(), value)
+
+
+def _reset_delayed_controller_queue(
+    queue: collections.deque,
+    neutral_controller,
+    reset_mask: np.ndarray,
+):
+  reset_mask = np.asarray(reset_mask, dtype=np.bool_)
+  for index, value in enumerate(queue):
+    queue[index] = utils.map_nt(
+        lambda controller, neutral: _reset_leaf(
+            controller, neutral, reset_mask),
+        value,
+        neutral_controller,
+    )
+
+
+def _reset_leaf(value, default, reset: np.ndarray):
+  while reset.ndim < value.ndim:
+    reset = reset[..., None]
+  return np.where(reset, default, value)

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -335,8 +335,8 @@ class JaxSimRolloutWorker:
           batch_slice=batch_slice,
       )
     timing = {
-        'state_copy': timings['state_copy'] / max(num_steps, 1),
-        'env_step': timings['env_step'] / max(num_steps, 1),
+        'env_pop': timings['state_copy'] / max(num_steps, 1),
+        'env_push': timings['env_step'] / max(num_steps, 1),
         'agent_step': {
             port: timings[f'agent_step_{port}'] / max(num_steps, 1)
             for port in self.ports

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -3,8 +3,8 @@
 The generic evaluator path builds libmelee-shaped Python objects once per port
 per frame. This worker uses `SimBatchedEnvironment.current_game_batch()` and
 `step_encoded()` instead: one reusable observation tree is filled from native
-sim buffers, one JAX actor samples both port perspectives, and the resulting
-trajectory is split back into the two port entries expected by the learner.
+sim buffers, JAX samples both port perspectives, and the resulting trajectory is
+split back into the port entries expected by the learner.
 """
 
 import collections
@@ -13,6 +13,7 @@ import time
 import typing as tp
 
 import jax
+import jax.numpy as jnp
 import melee
 import numpy as np
 
@@ -28,7 +29,7 @@ from slippi_ai.types import Game
 
 
 class JaxSimRolloutWorker:
-  """RolloutWorker-compatible adapter for JAX self-play on one sim batch."""
+  """RolloutWorker-compatible adapter for JAX policies on one sim batch."""
 
   ports: tuple[Port, Port] = (1, 2)
 
@@ -40,8 +41,17 @@ class JaxSimRolloutWorker:
       dolphin_kwargs: tp.Union[dict, tp.Sequence[dict]],
       num_envs: int,
       batch_steps: int = 1,
+      opponent_policy: policies.Policy | None = None,
+      train_opponent: bool = True,
+      use_fake_envs: bool = False,
   ):
     self._num_envs = int(num_envs)
+    self._num_players = self._num_envs * len(self.ports)
+    self._batch_slice_by_port = {
+        port: slice(i * self._num_envs, (i + 1) * self._num_envs)
+        for i, port in enumerate(self.ports)
+    }
+    self._train_ports = self.ports if train_opponent else (1,)
     if isinstance(dolphin_kwargs, dict):
       dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(self._num_envs)]
     elif self._num_envs != len(dolphin_kwargs):
@@ -51,35 +61,49 @@ class JaxSimRolloutWorker:
     else:
       dolphin_kwargs = list(dolphin_kwargs)
 
-    if set(agent_kwargs) != set(self.ports):
-      raise ValueError(
-          f'JAX sim rollout requires agent kwargs for ports {self.ports}.')
     agent1_kwargs = agent_kwargs[1]
     agent2_kwargs = agent_kwargs[2]
 
-    # Build one batched actor for both player perspectives. The learner sends
-    # one policy state, and this actor samples port-1 lanes followed by port-2
-    # lanes from the same current policy.
     should_compile = agent1_kwargs.get('compile', True)
-    if agent2_kwargs.get('compile', True) != should_compile:
-      raise ValueError('JAX sim rollout requires matching agent compile config.')
     state = agent1_kwargs['state']
-    name_code = np.asarray([
-        code
-        for kwargs in (agent1_kwargs, agent2_kwargs)
-        for code in eval_lib.get_name_codes(
-            kwargs['state'],
-            kwargs['name'],
-            batch_size=self._num_envs,
+    name_code_by_port = {
+        port: np.asarray(
+            eval_lib.get_name_codes(
+                kwargs['state'],
+                kwargs['name'],
+                batch_size=self._num_envs,
+            ),
+            dtype=NAME_DTYPE,
         )
-    ], dtype=NAME_DTYPE)
+        for port, kwargs in ((1, agent1_kwargs), (2, agent2_kwargs))
+    }
+    self._name_code = np.concatenate(
+        [name_code_by_port[port] for port in self.ports], axis=0)
 
-    self.actor = policy.build_agent(
-        batch_size=self._num_envs * 2,
-        name_code=name_code,
-        compile=should_compile,
-        pack_args=True,
-    )
+    # Same-policy self-play gets one actor over [port1 views, port2 views].
+    # Fixed-opponent rollout keeps that same env/action layout, but samples the
+    # two halves with separate policy objects and concatenates the outputs.
+    if opponent_policy is None:
+      self.actor = policy.build_agent(
+          batch_size=self._num_players,
+          name_code=self._name_code,
+          compile=should_compile,
+          pack_args=True,
+      )
+      self._opponent_actor = None
+    else:
+      self.actor = policy.build_agent(
+          batch_size=self._num_envs,
+          name_code=name_code_by_port[1],
+          compile=should_compile,
+          pack_args=True,
+      )
+      self._opponent_actor = opponent_policy.build_agent(
+          batch_size=self._num_envs,
+          name_code=name_code_by_port[2],
+          compile=should_compile,
+          pack_args=True,
+      )
 
     # Translate the Dolphin-style environment config into the smaller sim env
     # config. The sim path still accepts the same high-level launch config as
@@ -102,7 +126,6 @@ class JaxSimRolloutWorker:
         int(controller_config['axis_spacing']),
         int(controller_config['shoulder_spacing']),
     )
-    self._name_code = name_code
     self._batch_steps = max(1, int(batch_steps))
     self._frame_buffer_length = 0
     self._env_kwargs = dict(
@@ -112,6 +135,7 @@ class JaxSimRolloutWorker:
         character_pool=None,
         max_frame_id=(
             -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
+        fake=use_fake_envs,
     )
 
     # The sim env is created lazily from rollout(num_steps), matching the
@@ -121,7 +145,7 @@ class JaxSimRolloutWorker:
     self._state_buffer = None
     self._reset_buffer = None
     self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
-        [self._num_envs * 2])
+        [self._num_players])
     self._reset_delay_queues()
 
   def _reset_delay_queues(self):
@@ -151,14 +175,13 @@ class JaxSimRolloutWorker:
     self._reset_delay_queues()
 
   def update_variables(self, updates):
-    if not updates:
-      raise ValueError('JAX sim rollout update_variables requires policy values.')
-    unknown_ports = set(updates) - set(self.ports)
-    if unknown_ports:
-      raise ValueError(f'Unexpected policy update ports: {unknown_ports}')
-    # This worker is for same-policy self-play: one actor controls both ports,
-    # so any provided port update is the same learner policy state.
-    self.actor._policy.set_state(updates.get(1, updates.get(2)))
+    if self._opponent_actor is None:
+      self.actor._policy.set_state(updates.get(1, updates.get(2)))
+      return
+    if 1 in updates:
+      self.actor._policy.set_state(updates[1])
+    if 2 in updates:
+      self._opponent_actor._policy.set_state(updates[2])
 
   def rollout(
       self,
@@ -174,11 +197,18 @@ class JaxSimRolloutWorker:
       self._state_buffer = _make_trajectory_state_buffer(
           game_batch.game, num_steps)
       self._reset_buffer = np.empty(
-          (num_steps + 1, self._num_envs * 2), dtype=np.bool_)
+          (num_steps + 1, self._num_players), dtype=np.bool_)
     state_buffer = self._state_buffer
     reset_buffer = self._reset_buffer
     trajectory_actions = []
     initial_state = self.actor.hidden_state()
+    if self._opponent_actor is None:
+      initial_state_by_port = {
+          port: utils.map_single_structure(lambda x: x[batch_slice], initial_state)
+          for port, batch_slice in self._batch_slice_by_port.items()
+      }
+    else:
+      initial_state_by_port = {1: initial_state}
 
     # Step the sim immediately with already-delayed controller inputs, while
     # collecting a chunk of observations for one fused JAX actor call.
@@ -195,11 +225,9 @@ class JaxSimRolloutWorker:
         reset_buffer[t] = game_batch.needs_reset
         timings['state_copy'] += time.perf_counter() - copy_start
 
-        reset_mask = game_batch.needs_reset
+        reset_mask = reset_buffer[t]
         chunk_inputs.append((state_buffer.slots[t], reset_mask))
-        # Keep the per-frame reset mask stable while later sim steps reuse the
-        # game_batch buffers and while the chunk replay rebuilds delayed inputs.
-        chunk_reset_masks.append(reset_mask.copy())
+        chunk_reset_masks.append(reset_mask)
         if np.any(reset_mask):
           _reset_delayed_controller_queue(
               self._delayed_controller_queue,
@@ -219,15 +247,52 @@ class JaxSimRolloutWorker:
         game_batch = self._env.current_game_batch(self._needs_reset)
         timings['env_step'] += time.perf_counter() - env_start
 
-      step_start = time.perf_counter()
-      if chunk_len == 1:
-        chunk_outputs = jax.tree.map(
-            lambda x: x[None],
-            self.actor.step_device(chunk_inputs[0][0], chunk_inputs[0][1]),
-        )
+      if self._opponent_actor is None:
+        step_start = time.perf_counter()
+        chunk_outputs = _sample_chunk(self.actor, chunk_inputs)
+        # Pull the whole stacked chunk to host once. Later delayed-controller
+        # replay and trajectory assembly slice these arrays many times, and
+        # doing that slicing on JAX device arrays creates thousands of tiny ops.
+        chunk_outputs = jax.tree.map(np.asarray, chunk_outputs)
+        elapsed = time.perf_counter() - step_start
+        elapsed_per_port = elapsed / len(self.ports)
+        for port in self.ports:
+          timings[f'agent_step_{port}'] += elapsed_per_port
       else:
-        chunk_outputs = self.actor.multi_step_stacked_device(chunk_inputs)
-      timings['agent_step'] += time.perf_counter() - step_start
+        main_inputs = [
+            (
+                utils.map_single_structure(
+                    lambda x: x[self._batch_slice_by_port[1]], game),
+                reset[self._batch_slice_by_port[1]],
+            )
+            for game, reset in chunk_inputs
+        ]
+        opponent_inputs = [
+            (
+                utils.map_single_structure(
+                    lambda x: x[self._batch_slice_by_port[2]], game),
+                reset[self._batch_slice_by_port[2]],
+            )
+            for game, reset in chunk_inputs
+        ]
+        main_start = time.perf_counter()
+        main_outputs = _sample_chunk(self.actor, main_inputs)
+        timings['agent_step_1'] += time.perf_counter() - main_start
+
+        opponent_start = time.perf_counter()
+        opponent_outputs = _sample_chunk(self._opponent_actor, opponent_inputs)
+        timings['agent_step_2'] += time.perf_counter() - opponent_start
+
+        chunk_outputs = jax.tree.map(
+            lambda a, b: jnp.concatenate([a, b], axis=1),
+            main_outputs,
+            opponent_outputs,
+        )
+        materialize_start = time.perf_counter()
+        chunk_outputs = jax.tree.map(np.asarray, chunk_outputs)
+        elapsed = time.perf_counter() - materialize_start
+        timings['agent_step_1'] += elapsed / 2.0
+        timings['agent_step_2'] += elapsed / 2.0
       _replay_delayed_controller_queue(
           self._delayed_controller_queue,
           controller_queue_start,
@@ -256,16 +321,15 @@ class JaxSimRolloutWorker:
     timings['trajectory_build'] = time.perf_counter() - build_start
 
     trajectories = {}
-    for port, batch_slice in (
-        (1, slice(0, self._num_envs)),
-        (2, slice(self._num_envs, self._num_envs * 2)),
-    ):
+    for port, batch_slice in self._batch_slice_by_port.items():
+      if port not in self._train_ports:
+        continue
       trajectories[port] = _trajectory_slice(
           states=encoded_states,
           actions=batched_actions,
           rewards=rewards,
           is_resetting=reset_buffer,
-          initial_state=initial_state,
+          initial_state=initial_state_by_port[port],
           delayed_actions=delayed_actions,
           name_code=self._name_code,
           batch_slice=batch_slice,
@@ -274,7 +338,7 @@ class JaxSimRolloutWorker:
         'state_copy': timings['state_copy'] / max(num_steps, 1),
         'env_step': timings['env_step'] / max(num_steps, 1),
         'agent_step': {
-            port: timings['agent_step'] / max(num_steps, 1)
+            port: timings[f'agent_step_{port}'] / max(num_steps, 1)
             for port in self.ports
         },
         'trajectory_build': timings['trajectory_build'],
@@ -373,8 +437,7 @@ def _trajectory_slice(
       actions=utils.map_single_structure(lambda x: x[:, batch_slice], actions),
       rewards=rewards[:, batch_slice],
       is_resetting=is_resetting[:, batch_slice].copy(),
-      initial_state=utils.map_single_structure(
-          lambda x: x[batch_slice], initial_state),
+      initial_state=initial_state,
       delayed_actions=[
           utils.map_single_structure(lambda x: x[batch_slice], action)
           for action in delayed_actions
@@ -384,6 +447,15 @@ def _trajectory_slice(
 
 def _batch_actions(actions: list[SampleOutputs]) -> SampleOutputs:
   return jax.tree.map(lambda *xs: np.stack(xs, axis=0), *actions)
+
+
+def _sample_chunk(actor, chunk_inputs):
+  if len(chunk_inputs) == 1:
+    return jax.tree.map(
+        lambda x: x[None],
+        actor.step_device(chunk_inputs[0][0], chunk_inputs[0][1]),
+    )
+  return actor.multi_step_stacked_device(chunk_inputs)
 
 
 def _replay_delayed_controller_queue(

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -9,6 +9,7 @@ entries expected by the learner.
 """
 
 import collections
+import contextlib
 import itertools
 import time
 import typing as tp
@@ -165,8 +166,19 @@ class JaxSimRolloutWorker:
   def start(self):
     pass
 
+  @contextlib.contextmanager
+  def run(self):
+    try:
+      self.start()
+      yield
+    finally:
+      self.stop()
+
   def stop(self):
     self._env.stop()
+
+  def active_sim_games(self) -> list[dict[str, int | str]]:
+    return self._env.active_games()
 
   def reset_env(self):
     self.stop()

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -135,7 +135,6 @@ class JaxSimRolloutWorker:
         num_envs=self._num_envs,
         players=[kwargs['players'] for kwargs in dolphin_kwargs],
         stage=stages,
-        character_pool=None,
         max_frame_id=(
             -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
         fake=use_fake_envs,

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -40,6 +40,7 @@ class JaxSimRolloutWorker:
       agent_kwargs: tp.Mapping[int, dict],
       dolphin_kwargs: tp.Union[dict, tp.Sequence[dict]],
       num_envs: int,
+      rollout_length: int,
       batch_steps: int = 1,
       opponent_policy: policies.Policy | None = None,
       train_opponent: bool = True,
@@ -47,6 +48,7 @@ class JaxSimRolloutWorker:
   ):
     self._num_envs = int(num_envs)
     self._num_players = self._num_envs * len(self.ports)
+    self._rollout_length = int(rollout_length)
     self._batch_slice_by_port = {
         port: slice(i * self._num_envs, (i + 1) * self._num_envs)
         for i, port in enumerate(self.ports)
@@ -135,7 +137,6 @@ class JaxSimRolloutWorker:
         int(controller_config['shoulder_spacing']),
     )
     self._batch_steps = max(1, int(batch_steps))
-    self._frame_buffer_length = 0
     self._env_kwargs = dict(
         num_envs=self._num_envs,
         players=dolphin_kwargs_0['players'],
@@ -144,16 +145,18 @@ class JaxSimRolloutWorker:
         max_frame_id=(
             -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
         fake=use_fake_envs,
+        frame_buffer_length=self._rollout_length + self.actor._policy.delay + 2,
     )
 
-    # The sim env is created lazily from rollout(num_steps), matching the
-    # generic RolloutWorker API where rollout length is not constructor state.
-    self._env = None
-    self._needs_reset = None
-    self._state_buffer = None
-    self._reset_buffer = None
+    self._env = self._build_env()
+    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
     self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
         [self._num_players])
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._state_buffer = _make_trajectory_state_buffer(
+        game_batch.game, self._rollout_length)
+    self._reset_buffer = np.empty(
+        (self._rollout_length + 1, self._num_players), dtype=np.bool_)
     self._reset_delay_queues()
 
   def _reset_delay_queues(self):
@@ -170,16 +173,15 @@ class JaxSimRolloutWorker:
     pass
 
   def stop(self):
-    if self._env is not None:
-      self._env.stop()
-    self._env = None
-    self._needs_reset = None
-    self._state_buffer = None
-    self._reset_buffer = None
-    self._frame_buffer_length = 0
+    self._env.stop()
 
   def reset_env(self):
     self.stop()
+    self._env = self._build_env()
+    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._state_buffer = _make_trajectory_state_buffer(
+        game_batch.game, self._rollout_length)
     self._reset_delay_queues()
 
   def update_variables(self, updates):
@@ -199,13 +201,11 @@ class JaxSimRolloutWorker:
     del verbose
     timings: dict[str, float] = collections.defaultdict(float)
     num_steps = int(num_steps)
-    self._build_env_if_needed(num_steps)
+    if num_steps != self._rollout_length:
+      raise ValueError(
+          f'JaxSimRolloutWorker was built for rollout_length={self._rollout_length}, '
+          f'got rollout({num_steps}).')
     game_batch = self._env.current_game_batch(self._needs_reset)
-    if self._state_buffer is None:
-      self._state_buffer = _make_trajectory_state_buffer(
-          game_batch.game, num_steps)
-      self._reset_buffer = np.empty(
-          (num_steps + 1, self._num_players), dtype=np.bool_)
     state_buffer = self._state_buffer
     reset_buffer = self._reset_buffer
     trajectory_actions = []
@@ -356,25 +356,8 @@ class JaxSimRolloutWorker:
         'completed_games': self._env.pop_completed_games(),
     }
 
-  def _build_env_if_needed(self, num_steps: int):
-    frame_buffer_length = num_steps + self.actor._policy.delay + 2
-    if self._env is not None:
-      if self._frame_buffer_length >= frame_buffer_length:
-        return
-      self._env.stop()
-      self._env = None
-      self._needs_reset = None
-      self._state_buffer = None
-      self._reset_buffer = None
-      self._frame_buffer_length = 0
-
-    self._env = sim_env.SimBatchedEnvironment(
-        **self._env_kwargs,
-        frame_buffer_length=frame_buffer_length,
-    )
-    self._frame_buffer_length = frame_buffer_length
-    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
-    self._reset_delay_queues()
+  def _build_env(self):
+    return sim_env.SimBatchedEnvironment(**self._env_kwargs)
 
 
 class _TrajectoryStateBuffer(tp.NamedTuple):

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -117,13 +117,6 @@ class JaxSimRolloutWorker:
           itertools.cycle(sim_env.SUPPORTED_STAGES),
           self._num_envs,
       ))
-    character_pairs = [
-        tuple(kwargs['players'][port].character for port in self.ports)
-        for kwargs in dolphin_kwargs
-    ]
-    if any(pair != character_pairs[0] for pair in character_pairs):
-      raise ValueError(
-          'JAX sim rollout currently requires one character matchup per batch.')
 
     controller_config = state['config']['embed']['controller']
     other_config = agent2_kwargs['state']['config']['embed']['controller']
@@ -139,7 +132,7 @@ class JaxSimRolloutWorker:
     self._batch_steps = max(1, int(batch_steps))
     self._env_kwargs = dict(
         num_envs=self._num_envs,
-        players=dolphin_kwargs_0['players'],
+        players=[kwargs['players'] for kwargs in dolphin_kwargs],
         stage=stages,
         character_pool=None,
         max_frame_id=(

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -181,6 +181,32 @@ class SimEnvTest(unittest.TestCase):
     finally:
       env.stop()
 
+  def test_per_env_players_set_matchups(self):
+    env = self._sim_env(
+        num_envs=2,
+        frame_buffer_length=8,
+        players=[
+            {
+                1: dolphin.AI(melee.Character.FOX),
+                2: dolphin.AI(melee.Character.FALCO),
+            },
+            {
+                1: dolphin.AI(melee.Character.FALCO),
+                2: dolphin.AI(melee.Character.FOX),
+            },
+        ],
+    )
+    try:
+      state = env.current_game_batch(np.ones(2, dtype=np.bool_))
+      self.assertEqual(state.game.p0.character.tolist(), [
+          melee.Character.FOX.value,
+          melee.Character.FALCO.value,
+          melee.Character.FALCO.value,
+          melee.Character.FOX.value,
+      ])
+    finally:
+      env.stop()
+
   def test_character_pool_assignment_stays_fixed_on_reset(self):
     env = self._sim_env(
         num_envs=1,

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -16,6 +16,24 @@ class SimEnvTest(unittest.TestCase):
   def _sim_env(self, *args, **kwargs):
     try:
       return sim_env.SimBatchedEnvironment(*args, **kwargs)
+    except FileNotFoundError:
+      self.skipTest(
+          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
+          'extracted melee-sim-light data directory before running sim env tests.')
+    except MemoryError as exc:
+      if 'msl_batch_create failed' not in str(exc):
+        raise
+      self.skipTest(
+          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
+          'extracted melee-sim-light data directory before running sim env tests.')
+
+  def _rollout_or_skip(self, worker, steps: int):
+    try:
+      return worker.rollout(steps)
+    except FileNotFoundError:
+      self.skipTest(
+          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
+          'extracted melee-sim-light data directory before running sim env tests.')
     except MemoryError as exc:
       if 'msl_batch_create failed' not in str(exc):
         raise
@@ -275,6 +293,24 @@ class SimEnvTest(unittest.TestCase):
     finally:
       env.stop()
 
+  def test_fake_env_keeps_valid_observations_without_stepping(self):
+    env = self._sim_env(num_envs=2, frame_buffer_length=8, fake=True)
+    try:
+      encoded = _neutral_encoded_controller(batch_size=4)
+      before = env.current_game_batch(np.ones(2, dtype=np.bool_)).game.p0.x.copy()
+      needs_reset = env.step_encoded(
+          encoded,
+          axis_spacing=32,
+          shoulder_spacing=4,
+      )
+      after = env.current_game_batch(needs_reset).game.p0.x.copy()
+
+      self.assertFalse(np.any(needs_reset))
+      self.assertEqual(env.cursor, 0)
+      np.testing.assert_array_equal(before, after)
+    finally:
+      env.stop()
+
   def test_game_batch_matches_port_state_observation_conventions(self):
     env = self._sim_env(
         num_envs=3,
@@ -394,42 +430,18 @@ class SimEnvTest(unittest.TestCase):
     self.assertFalse(out.item_3.exists[0])
 
   def test_jax_rollout_worker_returns_learner_trajectories(self):
+    worker = jax_rollout.JaxSimRolloutWorker(
+        policy=_DummyPolicy(),
+        agent_kwargs={
+            1: _dummy_agent_kwargs(['A', 'B']),
+            2: _dummy_agent_kwargs(['B', 'A']),
+        },
+        dolphin_kwargs=_worker_dolphin_kwargs(),
+        num_envs=2,
+        batch_steps=2,
+    )
     try:
-      worker = jax_rollout.JaxSimRolloutWorker(
-          policy=_DummyPolicy(),
-          agent_kwargs={
-              1: _dummy_agent_kwargs(['A', 'B']),
-              2: _dummy_agent_kwargs(['B', 'A']),
-          },
-          dolphin_kwargs=[
-              dict(
-                  players={
-                      1: dolphin.AI(melee.Character.FOX),
-                      2: dolphin.AI(melee.Character.FALCO),
-                  },
-                  stage=melee.Stage.FINAL_DESTINATION,
-                  infinite_time=True,
-              ),
-              dict(
-                  players={
-                      1: dolphin.AI(melee.Character.FOX),
-                      2: dolphin.AI(melee.Character.FALCO),
-                  },
-                  stage=melee.Stage.BATTLEFIELD,
-                  infinite_time=True,
-              ),
-          ],
-          num_envs=2,
-          batch_steps=2,
-      )
-    except MemoryError as exc:
-      if 'msl_batch_create failed' not in str(exc):
-        raise
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
-    try:
-      trajectories, metrics = worker.rollout(4)
+      trajectories, metrics = self._rollout_or_skip(worker, 4)
 
       self.assertEqual(set(trajectories), {1, 2})
       self.assertEqual(trajectories[1].states.p0.x.shape, (5, 2))
@@ -439,6 +451,29 @@ class SimEnvTest(unittest.TestCase):
       self.assertEqual(trajectories[1].is_resetting.shape, (5, 2))
       self.assertTrue(np.all(trajectories[1].is_resetting[0]))
       self.assertIn('timing', metrics)
+    finally:
+      worker.stop()
+
+  def test_jax_rollout_worker_supports_fixed_opponent(self):
+    worker = jax_rollout.JaxSimRolloutWorker(
+        policy=_DummyPolicy(),
+        opponent_policy=_DummyPolicy(),
+        train_opponent=False,
+        agent_kwargs={
+            1: _dummy_agent_kwargs(['A', 'B']),
+            2: _dummy_agent_kwargs(['B', 'A']),
+        },
+        dolphin_kwargs=_worker_dolphin_kwargs(),
+        num_envs=2,
+        batch_steps=2,
+    )
+    try:
+      trajectories, metrics = self._rollout_or_skip(worker, 4)
+
+      self.assertEqual(set(trajectories), {1})
+      self.assertEqual(trajectories[1].states.p0.x.shape, (5, 2))
+      self.assertEqual(trajectories[1].initial_state.shape, (2,))
+      self.assertIn('completed_games', metrics)
     finally:
       worker.stop()
 
@@ -459,6 +494,20 @@ def _neutral_encoded_controller(batch_size: int):
           for name in Buttons._fields
       }),
   )
+
+
+def _worker_dolphin_kwargs():
+  return [
+      dict(
+          players={
+              1: dolphin.AI(melee.Character.FOX),
+              2: dolphin.AI(melee.Character.FALCO),
+          },
+          stage=stage,
+          infinite_time=True,
+      )
+      for stage in (melee.Stage.FINAL_DESTINATION, melee.Stage.BATTLEFIELD)
+  ]
 
 
 class _DummyNetwork:

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -5,8 +5,6 @@ import numpy as np
 
 from slippi_ai import dolphin
 from slippi_ai import sim_env
-from slippi_ai.controller_heads import SampleOutputs
-from slippi_ai.sim_env import jax_rollout
 from slippi_ai.sim_env import observations
 from slippi_ai.types import Buttons, Controller, Items, Stick
 
@@ -14,32 +12,7 @@ from slippi_ai.types import Buttons, Controller, Items, Stick
 class SimEnvTest(unittest.TestCase):
 
   def _sim_env(self, *args, **kwargs):
-    try:
-      return sim_env.SimBatchedEnvironment(*args, **kwargs)
-    except FileNotFoundError:
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
-    except MemoryError as exc:
-      if 'msl_batch_create failed' not in str(exc):
-        raise
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
-
-  def _rollout_or_skip(self, worker, steps: int):
-    try:
-      return worker.rollout(steps)
-    except FileNotFoundError:
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
-    except MemoryError as exc:
-      if 'msl_batch_create failed' not in str(exc):
-        raise
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
+    return sim_env.SimBatchedEnvironment(*args, **kwargs)
 
   def test_current_state_and_step_match_existing_game_shape(self):
     env = self._sim_env(
@@ -293,24 +266,6 @@ class SimEnvTest(unittest.TestCase):
     finally:
       env.stop()
 
-  def test_fake_env_keeps_valid_observations_without_stepping(self):
-    env = self._sim_env(num_envs=2, frame_buffer_length=8, fake=True)
-    try:
-      encoded = _neutral_encoded_controller(batch_size=4)
-      before = env.current_game_batch(np.ones(2, dtype=np.bool_)).game.p0.x.copy()
-      needs_reset = env.step_encoded(
-          encoded,
-          axis_spacing=32,
-          shoulder_spacing=4,
-      )
-      after = env.current_game_batch(needs_reset).game.p0.x.copy()
-
-      self.assertFalse(np.any(needs_reset))
-      self.assertEqual(env.cursor, 0)
-      np.testing.assert_array_equal(before, after)
-    finally:
-      env.stop()
-
   def test_game_batch_matches_port_state_observation_conventions(self):
     env = self._sim_env(
         num_envs=3,
@@ -429,54 +384,6 @@ class SimEnvTest(unittest.TestCase):
     self.assertEqual(out.item_2.x.tolist(), [-32.0])
     self.assertFalse(out.item_3.exists[0])
 
-  def test_jax_rollout_worker_returns_learner_trajectories(self):
-    worker = jax_rollout.JaxSimRolloutWorker(
-        policy=_DummyPolicy(),
-        agent_kwargs={
-            1: _dummy_agent_kwargs(['A', 'B']),
-            2: _dummy_agent_kwargs(['B', 'A']),
-        },
-        dolphin_kwargs=_worker_dolphin_kwargs(),
-        num_envs=2,
-        batch_steps=2,
-    )
-    try:
-      trajectories, metrics = self._rollout_or_skip(worker, 4)
-
-      self.assertEqual(set(trajectories), {1, 2})
-      self.assertEqual(trajectories[1].states.p0.x.shape, (5, 2))
-      self.assertEqual(trajectories[2].states.p0.x.shape, (5, 2))
-      self.assertEqual(trajectories[1].actions.controller_state.main_stick.x.shape, (5, 2))
-      self.assertEqual(len(trajectories[1].delayed_actions), 2)
-      self.assertEqual(trajectories[1].is_resetting.shape, (5, 2))
-      self.assertTrue(np.all(trajectories[1].is_resetting[0]))
-      self.assertIn('timing', metrics)
-    finally:
-      worker.stop()
-
-  def test_jax_rollout_worker_supports_fixed_opponent(self):
-    worker = jax_rollout.JaxSimRolloutWorker(
-        policy=_DummyPolicy(),
-        opponent_policy=_DummyPolicy(),
-        train_opponent=False,
-        agent_kwargs={
-            1: _dummy_agent_kwargs(['A', 'B']),
-            2: _dummy_agent_kwargs(['B', 'A']),
-        },
-        dolphin_kwargs=_worker_dolphin_kwargs(),
-        num_envs=2,
-        batch_steps=2,
-    )
-    try:
-      trajectories, metrics = self._rollout_or_skip(worker, 4)
-
-      self.assertEqual(set(trajectories), {1})
-      self.assertEqual(trajectories[1].states.p0.x.shape, (5, 2))
-      self.assertEqual(trajectories[1].initial_state.shape, (2,))
-      self.assertIn('completed_games', metrics)
-    finally:
-      worker.stop()
-
 def _neutral_encoded_controller(batch_size: int):
   shape = (int(batch_size),)
   return Controller(
@@ -493,116 +400,6 @@ def _neutral_encoded_controller(batch_size: int):
           name: np.zeros(shape, dtype=np.bool_)
           for name in Buttons._fields
       }),
-  )
-
-
-def _worker_dolphin_kwargs():
-  return [
-      dict(
-          players={
-              1: dolphin.AI(melee.Character.FOX),
-              2: dolphin.AI(melee.Character.FALCO),
-          },
-          stage=stage,
-          infinite_time=True,
-      )
-      for stage in (melee.Stage.FINAL_DESTINATION, melee.Stage.BATTLEFIELD)
-  ]
-
-
-class _DummyNetwork:
-
-  def encode_game(self, game):
-    return game
-
-
-class _DummyControllerHead:
-
-  def dummy_sample_outputs(self, shape):
-    controller = _neutral_encoded_controller(shape[0])
-    return SampleOutputs(
-        controller_state=controller,
-        logits=controller,
-    )
-
-
-class _DummyPolicy:
-  delay = 2
-  network = _DummyNetwork()
-  controller_head = _DummyControllerHead()
-
-  def set_state(self, values):
-    del values
-
-  def build_agent(self, batch_size: int, **kwargs):
-    return _DummyJaxActor(batch_size, kwargs['name_code'])
-
-
-class _DummyJaxActor:
-
-  def __init__(self, batch_size: int, name_code):
-    self._batch_size = int(batch_size)
-    self._policy = _DummyPolicy()
-    self.name_code = np.asarray(name_code, dtype=np.int32)
-    self.calls = 0
-
-  def hidden_state(self):
-    return np.zeros(self._batch_size, dtype=np.float32)
-
-  def step_device(self, game, needs_reset):
-    del game, needs_reset
-    self.calls += 1
-    return self._policy.controller_head.dummy_sample_outputs([self._batch_size])
-
-  def multi_step_stacked_device(self, states):
-    outputs = [
-        self.step_device(game, needs_reset)
-        for game, needs_reset in states
-    ]
-    return _stack_sample_outputs(outputs)
-
-
-def _stack_sample_outputs(outputs):
-  return SampleOutputs(
-      controller_state=_stack_controllers([
-          output.controller_state for output in outputs]),
-      logits=_stack_controllers([output.logits for output in outputs]),
-  )
-
-
-def _stack_controllers(controllers):
-  return Controller(
-      main_stick=Stick(
-          x=np.stack([c.main_stick.x for c in controllers], axis=0),
-          y=np.stack([c.main_stick.y for c in controllers], axis=0),
-      ),
-      c_stick=Stick(
-          x=np.stack([c.c_stick.x for c in controllers], axis=0),
-          y=np.stack([c.c_stick.y for c in controllers], axis=0),
-      ),
-      shoulder=np.stack([c.shoulder for c in controllers], axis=0),
-      buttons=Buttons(**{
-          name: np.stack([getattr(c.buttons, name) for c in controllers], axis=0)
-          for name in Buttons._fields
-      }),
-  )
-
-
-def _dummy_agent_kwargs(names):
-  return dict(
-      compile=True,
-      name=names,
-      state=dict(
-          name_map={'A': 0, 'B': 1},
-          config=dict(
-              embed=dict(
-                  controller=dict(
-                      type='default',
-                      default=dict(axis_spacing=32, shoulder_spacing=4),
-                  ),
-              ),
-          ),
-      ),
   )
 
 

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from slippi_ai import dolphin
 from slippi_ai import sim_env
+from slippi_ai.controller_heads import SampleOutputs
+from slippi_ai.sim_env import jax_rollout
 from slippi_ai.sim_env import observations
 from slippi_ai.types import Buttons, Controller, Items, Stick
 
@@ -391,6 +393,55 @@ class SimEnvTest(unittest.TestCase):
     self.assertEqual(out.item_2.x.tolist(), [-32.0])
     self.assertFalse(out.item_3.exists[0])
 
+  def test_jax_rollout_worker_returns_learner_trajectories(self):
+    try:
+      worker = jax_rollout.JaxSimRolloutWorker(
+          policy=_DummyPolicy(),
+          agent_kwargs={
+              1: _dummy_agent_kwargs(['A', 'B']),
+              2: _dummy_agent_kwargs(['B', 'A']),
+          },
+          dolphin_kwargs=[
+              dict(
+                  players={
+                      1: dolphin.AI(melee.Character.FOX),
+                      2: dolphin.AI(melee.Character.FALCO),
+                  },
+                  stage=melee.Stage.FINAL_DESTINATION,
+                  infinite_time=True,
+              ),
+              dict(
+                  players={
+                      1: dolphin.AI(melee.Character.FOX),
+                      2: dolphin.AI(melee.Character.FALCO),
+                  },
+                  stage=melee.Stage.BATTLEFIELD,
+                  infinite_time=True,
+              ),
+          ],
+          num_envs=2,
+          batch_steps=2,
+      )
+    except MemoryError as exc:
+      if 'msl_batch_create failed' not in str(exc):
+        raise
+      self.skipTest(
+          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
+          'extracted melee-sim-light data directory before running sim env tests.')
+    try:
+      trajectories, metrics = worker.rollout(4)
+
+      self.assertEqual(set(trajectories), {1, 2})
+      self.assertEqual(trajectories[1].states.p0.x.shape, (5, 2))
+      self.assertEqual(trajectories[2].states.p0.x.shape, (5, 2))
+      self.assertEqual(trajectories[1].actions.controller_state.main_stick.x.shape, (5, 2))
+      self.assertEqual(len(trajectories[1].delayed_actions), 2)
+      self.assertEqual(trajectories[1].is_resetting.shape, (5, 2))
+      self.assertTrue(np.all(trajectories[1].is_resetting[0]))
+      self.assertIn('timing', metrics)
+    finally:
+      worker.stop()
+
 def _neutral_encoded_controller(batch_size: int):
   shape = (int(batch_size),)
   return Controller(
@@ -407,6 +458,102 @@ def _neutral_encoded_controller(batch_size: int):
           name: np.zeros(shape, dtype=np.bool_)
           for name in Buttons._fields
       }),
+  )
+
+
+class _DummyNetwork:
+
+  def encode_game(self, game):
+    return game
+
+
+class _DummyControllerHead:
+
+  def dummy_sample_outputs(self, shape):
+    controller = _neutral_encoded_controller(shape[0])
+    return SampleOutputs(
+        controller_state=controller,
+        logits=controller,
+    )
+
+
+class _DummyPolicy:
+  delay = 2
+  network = _DummyNetwork()
+  controller_head = _DummyControllerHead()
+
+  def set_state(self, values):
+    del values
+
+  def build_agent(self, batch_size: int, **kwargs):
+    return _DummyJaxActor(batch_size, kwargs['name_code'])
+
+
+class _DummyJaxActor:
+
+  def __init__(self, batch_size: int, name_code):
+    self._batch_size = int(batch_size)
+    self._policy = _DummyPolicy()
+    self.name_code = np.asarray(name_code, dtype=np.int32)
+    self.calls = 0
+
+  def hidden_state(self):
+    return np.zeros(self._batch_size, dtype=np.float32)
+
+  def step_device(self, game, needs_reset):
+    del game, needs_reset
+    self.calls += 1
+    return self._policy.controller_head.dummy_sample_outputs([self._batch_size])
+
+  def multi_step_stacked_device(self, states):
+    outputs = [
+        self.step_device(game, needs_reset)
+        for game, needs_reset in states
+    ]
+    return _stack_sample_outputs(outputs)
+
+
+def _stack_sample_outputs(outputs):
+  return SampleOutputs(
+      controller_state=_stack_controllers([
+          output.controller_state for output in outputs]),
+      logits=_stack_controllers([output.logits for output in outputs]),
+  )
+
+
+def _stack_controllers(controllers):
+  return Controller(
+      main_stick=Stick(
+          x=np.stack([c.main_stick.x for c in controllers], axis=0),
+          y=np.stack([c.main_stick.y for c in controllers], axis=0),
+      ),
+      c_stick=Stick(
+          x=np.stack([c.c_stick.x for c in controllers], axis=0),
+          y=np.stack([c.c_stick.y for c in controllers], axis=0),
+      ),
+      shoulder=np.stack([c.shoulder for c in controllers], axis=0),
+      buttons=Buttons(**{
+          name: np.stack([getattr(c.buttons, name) for c in controllers], axis=0)
+          for name in Buttons._fields
+      }),
+  )
+
+
+def _dummy_agent_kwargs(names):
+  return dict(
+      compile=True,
+      name=names,
+      state=dict(
+          name_map={'A': 0, 'B': 1},
+          config=dict(
+              embed=dict(
+                  controller=dict(
+                      type='default',
+                      default=dict(axis_spacing=32, shoulder_spacing=4),
+                  ),
+              ),
+          ),
+      ),
   )
 
 


### PR DESCRIPTION
This PR adds a higher performance rollout worker for RL with `SimBatchedEnvironment` by avoiding the generic Dolphin-style rollout loop’s per-frame Python object rebuilds.

Added `slippi_ai/sim_env/jax_rollout.py`:
  - Uses SimBatchedEnvironment.current_game_batch() to read packed policy-facing observations from reusable buffers.
  - Uses SimBatchedEnvironment.step_encoded() to write encoded controller actions directly into the sim action ring.
  - Builds learner trajectories from packed rollout buffers instead of rebuilding Game objects per port/per frame.

Extended `slippi_ai/jax/agents.py`:
  - Added step_device() and multi_step_stacked_device() - these keep JAX sampled outputs on device until the rollout worker materializes one stacked chunk for sim input.

Tested via a small training run before/after the branch changes using the demo jax checkpoint in the repo:
```
num_envs: 256
rollout_length: 64
batch_steps: 8
ppo_batches: 4

Before:

rollout: 1.279s
learner: 0.077s
reset: 0.155s
total: 1.367s
env fps: 47.9k
player fps: 95.9k
agent_step_total: 0.019s

After:

rollout: 0.656s
learner: 0.074s
reset: 0.013s
total: 0.737s
env fps: 88.9k
player fps: 177.9k
agent_step_total: 0.001s
```

I also ran a couple short trainings, both in self-play and vs fixed opponent (using `all_d21_imitation_v3.pkl` as the base) to verify training still worked properly:
```
Self-play eval winrate vs base: 75-25
Fixed-opponent eval winrate vs base: 68-32
```