### PR TITLE
Add multiprocess sim environment

### DIFF
--- a/scripts/convert_tf_checkpoint_to_jax.py
+++ b/scripts/convert_tf_checkpoint_to_jax.py
@@ -1,0 +1,403 @@
+"""Convert legacy TensorFlow policy checkpoints into native JAX checkpoints."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import dataclasses
+import pickle
+from pathlib import Path
+import typing as tp
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+import tree
+
+from slippi_ai import data, observations, paths, reward, utils
+from slippi_ai.flag_utils import dataclass_from_dict
+from slippi_ai.jax import controller_heads, embed, jax_utils, networks, policies, saving
+
+
+ArrayTree = dict[str | int, tp.Any]
+_VERIFY_MAX_GAMES = 5
+_VERIFY_SUBSAMPLE = 100
+
+
+def _path_parts(path: str) -> list[str | int]:
+  result: list[str | int] = []
+  for part in path.split('/'):
+    result.append(int(part) if part.isdecimal() else part)
+  return result
+
+
+def _get_path(tree_: ArrayTree, path: str):
+  cursor = tree_
+  for part in _path_parts(path):
+    cursor = cursor[part]
+  return cursor
+
+
+def _set_path(params: ArrayTree, path: str, value: np.ndarray) -> None:
+  cursor = params
+  parts = _path_parts(path)
+  for part in parts[:-1]:
+    cursor = cursor[part]
+  expected = np.asarray(cursor[parts[-1]])
+  value = np.asarray(value)
+  if value.shape != expected.shape:
+    raise ValueError(
+        f'shape mismatch for {path}: source {value.shape} != target {expected.shape}')
+  cursor[parts[-1]] = value
+
+
+def _numeric_keys(mapping: dict) -> list[int]:
+  return sorted(key for key in mapping if isinstance(key, int))
+
+
+def _split_lstm_gates(x: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+  return tuple(np.split(np.asarray(x), 4, axis=-1))  # type: ignore[return-value]
+
+
+def _combined_kernel_shape(core: dict, gates: tuple[str, ...]) -> tuple[int, int]:
+  kernels = [np.asarray(core[gate]['kernel']) for gate in gates]
+  rows = {kernel.shape[0] for kernel in kernels}
+  if len(rows) != 1:
+    raise ValueError(f'inconsistent LSTM gate kernel input sizes: {rows}')
+  return (rows.pop(), sum(kernel.shape[1] for kernel in kernels))
+
+
+class LeafReader:
+  """Sequential TF leaf reader with target-shape validation."""
+
+  def __init__(self, source_state):
+    self._leaves = [np.asarray(x) for x in tree.flatten(source_state)]
+    self._index = 0
+
+  @property
+  def remaining(self) -> int:
+    return len(self._leaves) - self._index
+
+  def read(self, expected_shape: tuple[int, ...], label: str) -> np.ndarray:
+    if self._index >= len(self._leaves):
+      raise ValueError(f'ran out of TensorFlow leaves while reading {label}')
+    value = self._leaves[self._index]
+    if value.shape != expected_shape:
+      raise ValueError(
+          f'shape mismatch for TF leaf {self._index} ({label}): '
+          f'{value.shape} != {expected_shape}')
+    self._index += 1
+    return value
+
+  def finish(self):
+    if self._index != len(self._leaves):
+      raise ValueError(
+          f'converted {self._index} TensorFlow leaves but checkpoint has '
+          f'{len(self._leaves)} leaves')
+
+
+def _jax_config_from_tf_config(config: dict) -> dict:
+  config = copy.deepcopy(config)
+
+  # Old TF checkpoints predate the current JAX observation/embed config shape.
+  # Normalize the saved config first so the target JAX Policy is constructed
+  # with exactly the modules whose parameters we are about to populate.
+  if config.get('version') == 3:
+    config['observation'] = dataclasses.asdict(
+        observations.NULL_OBSERVATION_CONFIG)
+    config['version'] = 4
+
+  if config.get('version') == 4:
+    config['embed'].update(
+        with_randall=False,
+        with_fod=False,
+        items={'type': embed.ItemsType.SKIP},
+    )
+    config['embed']['player'].update(
+        with_nana=False,
+        legacy_jumps_left=True,
+    )
+    config['version'] = 5
+
+  if config.get('version') != 5:
+    raise ValueError(f"Unsupported legacy TF checkpoint version: {config.get('version')}")
+
+  controller = config['embed']['controller']
+  config['embed']['controller'] = {
+      'type': 'default',
+      'default': controller,
+  }
+
+  _upgrade_network_config(config['network'])
+  _upgrade_network_config(config['value_function']['network'])
+  config.setdefault('seed', 0)
+  config['platform'] = 'jax'
+  config['version'] = saving.VERSION
+  return config
+
+
+def _upgrade_network_config(config: dict):
+  config.setdefault('embed', {
+      'name': 'simple',
+      'simple': {},
+      'enhanced': networks.EnhancedEmbedModule.default_config(),
+  })
+  if config['name'] == 'tx_like':
+    config['tx_like']['layer_norm'] = 'tensorflow'
+    config['tx_like']['gelu_approximate'] = False
+
+
+def _policy_from_config(config: dict) -> policies.Policy:
+  embed_config = dataclass_from_dict(embed.EmbedConfig, config['embed'])
+  policy_config = dataclass_from_dict(policies.PolicyConfig, config['policy'])
+  rngs = nnx.Rngs(config.get('seed', 0))
+
+  network = networks.build_embed_network(
+      rngs=rngs,
+      embed_config=embed_config,
+      num_names=config['max_names'],
+      network_config=config['network'],
+  )
+  controller_head = controller_heads.construct(
+      rngs=rngs,
+      input_size=network.output_size,
+      embed_controller=embed_config.controller.make_embedding(),
+      **config['controller_head'],
+  )
+  return policies.Policy(
+      network=network,
+      controller_head=controller_head,
+      delay=policy_config.delay,
+  )
+
+
+def _convert_autoregressive_head(params: ArrayTree, reader: LeafReader) -> None:
+  head = params['_controller_head']
+  if 'res_blocks' not in head or 'to_residual' not in head:
+    raise ValueError('only legacy autoregressive TensorFlow controller heads are supported')
+
+  # The legacy TF pickle stores leaves in module traversal order. The JAX head
+  # has the same logical layers but different tree names, so conversion is a
+  # shape-checked replay of that known order into the target parameter tree.
+  for block_index in _numeric_keys(head['res_blocks']):
+    block = head['res_blocks'][block_index]
+    base = f'_controller_head/res_blocks/{block_index}'
+    _set_from_leaf(params, reader, f'{base}/decoder/bias')
+    _set_from_leaf(params, reader, f'{base}/decoder/kernel')
+    for layer_index in _numeric_keys(block['_encoder']['layers']):
+      layer_base = f'{base}/_encoder/layers/{layer_index}'
+      _set_from_leaf(params, reader, f'{layer_base}/bias')
+      _set_from_leaf(params, reader, f'{layer_base}/kernel')
+
+  _set_from_leaf(params, reader, '_controller_head/to_residual/bias')
+  _set_from_leaf(params, reader, '_controller_head/to_residual/kernel')
+
+
+def _set_from_leaf(params: ArrayTree, reader: LeafReader, path: str) -> None:
+  expected_shape = np.asarray(_get_path(params, path)).shape
+  value = reader.read(expected_shape, path)
+  _set_path(params, path, value)
+
+
+def _convert_network(params: ArrayTree, reader: LeafReader, network_config: dict) -> None:
+  if network_config['name'] != 'tx_like':
+    raise ValueError(
+        f"only legacy tx_like TensorFlow policy networks are supported; "
+        f"got {network_config['name']!r}")
+
+  layers = params['network']['_network']['_layers']
+  layer_indices = _numeric_keys(layers)
+  if not layer_indices or layer_indices[0] != 0:
+    raise ValueError('expected tx_like network layer 0 to be the input encoder')
+
+  _set_from_leaf(params, reader, 'network/_network/_layers/0/_module/bias')
+  _set_from_leaf(params, reader, 'network/_network/_layers/0/_module/kernel')
+
+  remaining = layer_indices[1:]
+  if len(remaining) % 2:
+    raise ValueError(f'expected recurrent/FFW layer pairs after encoder, got {remaining}')
+
+  for recurrent_layer, ffw_layer in zip(remaining[::2], remaining[1::2]):
+    _convert_lstm_layer(params, reader, recurrent_layer)
+    ffw_base = f'network/_network/_layers/{ffw_layer}/_module'
+    _set_from_leaf(params, reader, f'{ffw_base}/layernorm/bias')
+    _set_from_leaf(params, reader, f'{ffw_base}/layernorm/scale')
+    _set_from_leaf(params, reader, f'{ffw_base}/linear1/bias')
+    _set_from_leaf(params, reader, f'{ffw_base}/linear1/kernel')
+    _set_from_leaf(params, reader, f'{ffw_base}/linear2/bias')
+    _set_from_leaf(params, reader, f'{ffw_base}/linear2/kernel')
+
+
+def _skip_legacy_policy_value_readout(reader: LeafReader, network_config: dict) -> None:
+  """Skip the TF policy tuple's trailing value readout, if present.
+
+  Legacy TF policy checkpoints can carry a scalar value readout at the end of
+  the policy parameter tuple even though the saved checkpoint also has a
+  separate `state["value_function"]`. JAX `Policy` has no corresponding module,
+  and the previous converter did not use these leaves. Keep that behavior
+  explicit and shape-checked instead of silently accepting arbitrary leftovers.
+  """
+  if reader.remaining == 0:
+    return
+
+  tx_like = network_config.get('tx_like', {})
+  hidden_size = int(tx_like.get('hidden_size', 0))
+  if reader.remaining != 2 or hidden_size <= 0:
+    raise ValueError(
+        f'unsupported extra TensorFlow policy leaves: {reader.remaining} remain')
+
+  reader.read((1,), 'legacy policy value readout bias')
+  reader.read((hidden_size, 1), 'legacy policy value readout kernel')
+
+
+def _convert_lstm_layer(params: ArrayTree, reader: LeafReader, layer_index: int) -> None:
+  core_base = f'network/_network/_layers/{layer_index}/_net/_core'
+  core = _get_path(params, core_base)
+  if not all(gate in core for gate in ('hi', 'hf', 'hg', 'ho', 'ii', 'if_', 'ig', 'io')):
+    raise ValueError(f'only LSTM tx_like recurrent layers are supported: {core_base}')
+
+  hidden_shape = _combined_kernel_shape(core, ('hi', 'hf', 'hg', 'ho'))
+  input_shape = _combined_kernel_shape(core, ('ii', 'if_', 'ig', 'io'))
+  bias_shape = (sum(np.asarray(core[gate]['bias']).shape[0]
+                    for gate in ('hi', 'hf', 'hg', 'ho')),)
+
+  hidden_kernel = reader.read(hidden_shape, f'{core_base}/hidden_kernel')
+  input_kernel = reader.read(input_shape, f'{core_base}/input_kernel')
+  bias = reader.read(bias_shape, f'{core_base}/bias')
+
+  # TF keeps each LSTM core as combined i/f/g/o matrices; the JAX module stores
+  # one small linear per gate. Split the combined tensors without changing gate
+  # order so converted checkpoints remain numerically equivalent.
+  for gate_name, gate_value in zip(('hi', 'hf', 'hg', 'ho'), _split_lstm_gates(hidden_kernel)):
+    _set_path(params, f'{core_base}/{gate_name}/kernel', gate_value)
+  for gate_name, gate_value in zip(('ii', 'if_', 'ig', 'io'), _split_lstm_gates(input_kernel)):
+    _set_path(params, f'{core_base}/{gate_name}/kernel', gate_value)
+  for gate_name, gate_value in zip(('hi', 'hf', 'hg', 'ho'), _split_lstm_gates(bias)):
+    _set_path(params, f'{core_base}/{gate_name}/bias', gate_value)
+
+
+def convert_state(source_state: dict) -> dict:
+  config = _jax_config_from_tf_config(source_state['config'])
+  policy = _policy_from_config(config)
+  params = jax_utils.get_module_state(policy)
+  reader = LeafReader(source_state['state']['policy'])
+
+  _convert_autoregressive_head(params, reader)
+  _convert_network(params, reader, config['network'])
+  _skip_legacy_policy_value_readout(reader, config['network'])
+  reader.finish()
+
+  # TODO: Convert optimizer/value-function state.
+  return {
+      'state': {'policy': params},
+      'config': config,
+      'name_map': copy.deepcopy(source_state.get('name_map', {})),
+      'step': int(source_state.get('step', source_state['state'].get('step', 0))),
+  }
+
+
+def convert_file(source_path: str | Path, output_path: str | Path) -> None:
+  source_path = Path(source_path)
+  output_path = Path(output_path)
+  with source_path.open('rb') as f:
+    source_state = pickle.load(f)
+  converted = convert_state(source_state)
+  output_path.parent.mkdir(parents=True, exist_ok=True)
+  with output_path.open('wb') as f:
+    pickle.dump(converted, f)
+
+
+def _frames(path: Path) -> data.Frames:
+  game = data.read_table(str(path), compressed=True)
+  state_action = data.StateAction(
+      game, game.p0.controller, np.zeros(len(game.stage), np.int32))
+  is_resetting = np.zeros(len(game.stage), np.bool_)
+  is_resetting[0] = True
+  return data.Frames(state_action, is_resetting, reward.compute_rewards(game))
+
+
+def _tf_logits(source_path: Path, game_path: Path):
+  from slippi_ai.tf import saving as tf_saving
+
+  policy = tf_saving.load_policy_from_disk(str(source_path))
+  frames = _frames(game_path)
+  frames = frames._replace(state_action=policy.network.encode(frames.state_action))
+  frames = utils.map_nt(lambda x: np.expand_dims(x, 1), frames)
+  outputs = policy.unroll(frames, policy.initial_state(1))
+  return utils.map_nt(
+      lambda x: np.squeeze(x.numpy(), 1)[::_VERIFY_SUBSAMPLE],
+      outputs.distances.logits)
+
+
+def _jax_logits(output_path: Path, game_path: Path):
+  policy = saving.load_policy_from_state(saving.load_state_from_disk(str(output_path)))
+  frames = _frames(game_path)
+  frames = frames._replace(state_action=policy.network.encode(frames.state_action))
+  frames = utils.map_nt(lambda x: jnp.expand_dims(jnp.asarray(x), 1), frames)
+  outputs = policy.unroll(frames, policy.initial_state(1))
+  logits = utils.map_nt(
+      lambda x: np.squeeze(np.asarray(x), 1)[::_VERIFY_SUBSAMPLE],
+      outputs.distances.logits)
+  return policy.controller_head.controller_embedding, logits
+
+
+def _sum_leaves(xs):
+  total = None
+  for x in jax.tree.leaves(xs):
+    total = x if total is None else total + x
+  return total
+
+
+def _verify_game(source_path: Path, output_path: Path, game_path: Path) -> dict[str, float]:
+  tf_logits = _tf_logits(source_path, game_path)
+  embedding, jax_logits = _jax_logits(output_path, game_path)
+  kl_tf_jax = _sum_leaves(embedding.map(
+      lambda e, p, q: e.kl_divergence(jnp.asarray(p), jnp.asarray(q)),
+      tf_logits, jax_logits))
+  kl_jax_tf = _sum_leaves(embedding.map(
+      lambda e, p, q: e.kl_divergence(jnp.asarray(p), jnp.asarray(q)),
+      jax_logits, tf_logits))
+  max_abs = max(
+      float(np.max(np.abs(np.asarray(a) - np.asarray(b))))
+      for a, b in zip(tree.flatten(tf_logits), tree.flatten(jax_logits)))
+  return {
+      'mean_kl_tf_to_jax': float(jnp.mean(kl_tf_jax)),
+      'max_kl_tf_to_jax': float(jnp.max(kl_tf_jax)),
+      'mean_kl_jax_to_tf': float(jnp.mean(kl_jax_tf)),
+      'max_abs_logit_diff': max_abs,
+  }
+
+
+def verify_file(source_path: str | Path, output_path: str | Path, data_dir: str | Path) -> None:
+  source_path = Path(source_path)
+  output_path = Path(output_path)
+  game_paths = sorted(path for path in Path(data_dir).rglob('*') if path.is_file())
+  game_paths = game_paths[:_VERIFY_MAX_GAMES]
+  if not game_paths:
+    raise ValueError(f'no verification games found under {data_dir}')
+
+  stats = [_verify_game(source_path, output_path, path) for path in game_paths]
+  print(f'verify_data_dir: {data_dir}')
+  print(f'verify_games: {len(game_paths)}')
+  for key in stats[0]:
+    values = [item[key] for item in stats]
+    print(f'{key}: mean={np.mean(values):.6g} max={np.max(values):.6g}')
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('source', help='legacy TensorFlow pickle checkpoint')
+  parser.add_argument('output', help='output JAX pickle checkpoint')
+  parser.add_argument(
+      '--verify-data-dir',
+      default=str(paths.TOY_DATA_DIR),
+      help='run post-conversion TF/JAX parity on parsed game tables (defaults to toy data)')
+  args = parser.parse_args()
+
+  convert_file(args.source, args.output)
+  verify_file(args.source, args.output, args.verify_data_dir)
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/run_evaluator.py
+++ b/scripts/run_evaluator.py
@@ -138,6 +138,8 @@ if __name__ == '__main__':
     )
     if NUM_GAMES.value and not SIM_ENVS.value:
       raise ValueError('--num_games currently requires --sim_envs.')
+    if SIM_ENVS.value and ASYNC_ENVS.value and NUM_ENV_STEPS.value:
+      raise ValueError('--num_env_steps is not used by sim async envs.')
 
     use_jax_sim_worker = (
         SIM_ENVS.value and
@@ -163,6 +165,8 @@ if __name__ == '__main__':
           rollout_length=ROLLOUT_LENGTH.value,
           batch_steps=NUM_AGENT_STEPS.value,
           use_fake_envs=FAKE_ENVS.value,
+          async_envs=ASYNC_ENVS.value,
+          inner_batch_size=INNER_BATCH_SIZE.value,
       )
     else:
       evaluator = evaluators.Evaluator(**evaluator_kwargs)

--- a/scripts/run_evaluator.py
+++ b/scripts/run_evaluator.py
@@ -138,8 +138,6 @@ if __name__ == '__main__':
     )
     if NUM_GAMES.value and not SIM_ENVS.value:
       raise ValueError('--num_games currently requires --sim_envs.')
-    if SIM_ENVS.value and ASYNC_ENVS.value and NUM_ENV_STEPS.value:
-      raise ValueError('--num_env_steps is not used by sim async envs.')
 
     use_jax_sim_worker = (
         SIM_ENVS.value and

--- a/scripts/run_evaluator.py
+++ b/scripts/run_evaluator.py
@@ -10,7 +10,8 @@ if __name__ == '__main__':
   from absl import app, flags
   import fancyflags as ff
 
-  from slippi_ai import eval_lib, dolphin, utils, evaluators, flag_utils, saving
+  from slippi_ai import (
+      eval_lib, dolphin, utils, evaluators, flag_utils, policies, saving)
 
   default_dolphin_config = dolphin.DolphinConfig(
       infinite_time=False,
@@ -138,12 +139,40 @@ if __name__ == '__main__':
     if NUM_GAMES.value and not SIM_ENVS.value:
       raise ValueError('--num_games currently requires --sim_envs.')
 
-    evaluator = evaluators.Evaluator(**evaluator_kwargs)
+    use_jax_sim_worker = (
+        SIM_ENVS.value and
+        len(agent_kwargs) == 2 and
+        all(
+            saving.get_platform(kwargs['state']['config']) is policies.Platform.JAX
+            for kwargs in agent_kwargs.values()
+        )
+    )
+    if use_jax_sim_worker:
+      from slippi_ai.sim_env import jax_rollout
+
+      train_opponent = SELF_PLAY.value
+      evaluator = jax_rollout.JaxSimRolloutWorker(
+          policy=saving.load_policy_from_state(agent_kwargs[1]['state']),
+          opponent_policy=(
+              None if train_opponent else
+              saving.load_policy_from_state(agent_kwargs[2]['state'])),
+          train_opponent=train_opponent,
+          agent_kwargs=agent_kwargs,
+          dolphin_kwargs=dolphin_kwargs,
+          num_envs=NUM_ENVS.value,
+          rollout_length=ROLLOUT_LENGTH.value,
+          batch_steps=NUM_AGENT_STEPS.value,
+          use_fake_envs=FAKE_ENVS.value,
+      )
+    else:
+      evaluator = evaluators.Evaluator(**evaluator_kwargs)
 
     with evaluator.run():
       # burnin
       batch_steps = NUM_AGENT_STEPS.value or 1
       burnin_steps = math.ceil(32 / batch_steps) * batch_steps
+      if use_jax_sim_worker:
+        burnin_steps = ROLLOUT_LENGTH.value
       evaluator.rollout(burnin_steps)
 
       if TF_PROFILE.value:
@@ -176,6 +205,11 @@ if __name__ == '__main__':
       with timer:
         while True:
           stats, metrics = evaluator.rollout(ROLLOUT_LENGTH.value, verbose=True)
+          if use_jax_sim_worker:
+            stats = {
+                port: evaluators.RolloutMetrics.from_trajectory(trajectory)
+                for port, trajectory in stats.items()
+            }
           total_steps += ROLLOUT_LENGTH.value
           for port, stat in stats.items():
             rewards[port] = rewards.get(port, 0) + stat.reward

--- a/slippi_ai/eval_lib.py
+++ b/slippi_ai/eval_lib.py
@@ -337,6 +337,21 @@ def get_name_code(state: dict, name: str) -> int:
     raise ValueError(f'Nametag must be one of {name_map.keys()}.')
   return name_map[name]
 
+
+def get_name_codes(
+    state: dict,
+    name: str | tp.Sequence[str],
+    batch_size: int | None = None,
+) -> int | list[int]:
+  if isinstance(name, str):
+    code = get_name_code(state, name)
+    return code if batch_size is None else [code] * batch_size
+  codes = [get_name_code(state, n) for n in name]
+  if batch_size is not None and len(codes) != batch_size:
+    raise ValueError(f'Nametag batch must have length batch_size={batch_size}')
+  return codes
+
+
 def get_agent_config(state: dict) -> tp.Optional[dict]:
   # TODO: unify self-train and train-two
   if 'rl_config' in state:  # self-train aka rl/run.py
@@ -395,10 +410,7 @@ def build_delayed_agent(
     # TODO: just pick from the name_map?
     raise ValueError('Must specify an agent name.')
 
-  if isinstance(name, str):
-    name_code = get_name_code(state, name)
-  else:
-    name_code = [get_name_code(state, n) for n in name]
+  name_code = get_name_codes(state, name)
 
   # Stick the observation_config into the agent for future use.
   observation_config = flag_utils.dataclass_from_dict(

--- a/slippi_ai/evaluators.py
+++ b/slippi_ai/evaluators.py
@@ -71,8 +71,12 @@ class RolloutWorker:
   ):
     if isinstance(dolphin_kwargs, dict):
       dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(num_envs)]
+    elif num_envs != len(dolphin_kwargs):
+      raise ValueError(
+          f'num_envs={num_envs} does not match '
+          f'{len(dolphin_kwargs)} dolphin kwargs entries.')
     else:
-      assert num_envs == len(dolphin_kwargs)
+      dolphin_kwargs = list(dolphin_kwargs)
     self._dolphin_kwargs = dolphin_kwargs
 
     dolphin_kwargs_0 = dolphin_kwargs[0]
@@ -175,11 +179,6 @@ class RolloutWorker:
     if self._use_fake_envs:
       raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
 
-    characters = set(
-        player.character
-        for kwargs in self._dolphin_kwargs
-        for player in kwargs['players'].values()
-    )
     stages = [kwargs['stage'] for kwargs in self._dolphin_kwargs]
     if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
       stages = tuple(itertools.islice(
@@ -190,9 +189,8 @@ class RolloutWorker:
 
     return sim_env.SimBatchedEnvironment(
         num_envs=self._num_envs,
-        players=first_kwargs['players'],
+        players=[kwargs['players'] for kwargs in self._dolphin_kwargs],
         stage=stages,
-        character_pool=characters,
         max_frame_id=max_frame_id,
     )
 
@@ -385,7 +383,6 @@ class RolloutMetrics(tp.NamedTuple):
   @classmethod
   def from_trajectory(cls, trajectory: Trajectory) -> tp.Self:
     return cls(reward=np.sum(trajectory.rewards))
-
 
 class Evaluator(RolloutWorker):
 

--- a/slippi_ai/jax/agents.py
+++ b/slippi_ai/jax/agents.py
@@ -85,7 +85,7 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
         name_code: jax.Array,
         prev_action: ControllerType,  # only for first step
         initial_state: policies.RecurrentState,
-    ) -> tuple[list[SampleOutputs[ControllerType]], policies.RecurrentState]:
+    ) -> tuple[SampleOutputs[ControllerType], policies.RecurrentState]:
 
       stacked_states_and_resets = jax.tree.map(
           lambda *xs: jnp.stack(xs, axis=0), *states_and_resets)
@@ -107,11 +107,7 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
       stacked_sample_outputs, (_, final_state) = scan_fn(
           rngs.fork(split=length), stacked_states_and_resets, (prev_action, initial_state))
 
-      sample_outputs = [
-          jax.tree.map(lambda t, i=i: t[i], stacked_sample_outputs)
-          for i in range(length)]
-
-      return sample_outputs, final_state
+      return stacked_sample_outputs, final_state
 
     self._multi_sample = jax_utils.cached_partial(multi_sample, policy, rngs)
 
@@ -158,6 +154,15 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
       needs_reset: agents.BoolArray,
   ) -> SampleOutputs[ControllerType]:
     """Doesn't take into account delay."""
+    sample_outputs = self.step_device(game, needs_reset)
+    return jax.copy_to_host_async(sample_outputs)
+
+  def step_device(
+      self,
+      game: Game,
+      needs_reset: agents.BoolArray,
+  ) -> SampleOutputs[ControllerType]:
+    """Sample an action and leave the output tree on device."""
     game = self._policy.network.encode_game(game)
     # Keep hidden state and prev_controller on device.
     sample_fn = self._jitted_sample if self._compile else self._sample
@@ -167,23 +172,36 @@ class BasicAgent(agents.BasicAgent[ControllerType, policies.RecurrentState]):
     # Use donate_argnums?
     self._prev_controller = sample_outputs.controller_state
 
-    # Convert to numpy?
-    return jax.copy_to_host_async(sample_outputs)
+    return sample_outputs
 
   def multi_step(
       self,
       states: list[tuple[Game, agents.BoolArray]],
   ) -> list[SampleOutputs[ControllerType]]:
+    sample_outputs = self.multi_step_stacked_device(states)
+    sample_outputs = jax.tree.map(np.asarray, sample_outputs)
+    sample_outputs = [
+        jax.tree.map(lambda t, i=i: t[i], sample_outputs)
+        for i in range(len(states))]
+    return sample_outputs
+
+  def multi_step_stacked_device(
+      self,
+      states: list[tuple[Game, agents.BoolArray]],
+  ) -> SampleOutputs[ControllerType]:
+    # Fast rollout code consumes a whole time chunk at once. Returning the
+    # stacked device tree avoids per-frame Python objects and host copies; the
+    # compatibility `multi_step` wrapper above still provides the old list API.
     states_and_resets = [
         (self._policy.network.encode_game(game), needs_reset)
         for game, needs_reset in states
     ]
-
     # Keep hidden state and _prev_controller on device.
     multi_sample_fn = self._jitted_multi_sample if self._compile else self._multi_sample
     sample_outputs, self._hidden_state = multi_sample_fn(
         states_and_resets, self._name_code, self._prev_controller, self._hidden_state)
 
-    self._prev_controller = sample_outputs[-1].controller_state
+    self._prev_controller = jax.tree.map(
+        lambda t: t[-1], sample_outputs.controller_state)
 
-    return jax.copy_to_host_async(sample_outputs)
+    return sample_outputs

--- a/slippi_ai/jax/networks.py
+++ b/slippi_ai/jax/networks.py
@@ -491,6 +491,38 @@ class LSTM(RecurrentWrapper, BuildableNetwork[Array, Array]):
         remat=remat)
 
 
+# This deliberately does not use `nnx.LayerNorm`.
+#
+# Legacy TensorFlow policies used a last-axis layer norm equivalent to:
+#
+#   centered = x - mean(x)
+#   normalized = centered / sqrt(mean(centered ** 2))
+#   y = normalized * scale + bias
+#
+# Flax/NNX LayerNorm includes its own epsilon/stabilization behavior in the
+# denominator. That is the default for JAX-native `tx_like` models, but it is
+# not algebraically identical to the TensorFlow checkpoint computation.
+# Converted recurrent policies are sensitive to this: small activation/logit
+# differences can compound over many frames and noticeably change gameplay.
+#
+# Use this only when checkpoint config explicitly sets `layer_norm =
+# "tensorflow"` for legacy checkpoint parity. Converted checkpoints also set
+# `gelu_approximate = False` for the same reason: TensorFlow used the exact GELU
+# formula, while JAX-native configs default to the faster approximate GELU.
+class TensorFlowLayerNorm(nnx.Module):
+  """TensorFlow-policy-compatible last-axis layer norm."""
+
+  def __init__(self, residual_size: int, rngs: nnx.Rngs):
+    del rngs
+    self.scale = nnx.Param(jnp.ones((residual_size,), dtype=jnp.float32))
+    self.bias = nnx.Param(jnp.zeros((residual_size,), dtype=jnp.float32))
+
+  def __call__(self, inputs: Array) -> Array:
+    centered = inputs - jnp.mean(inputs, axis=-1, keepdims=True)
+    stddev = jnp.sqrt(jnp.mean(jnp.square(centered), axis=-1, keepdims=True))
+    return centered / stddev * self.scale + self.bias
+
+
 class ResBlock(nnx.Module):
 
   def __init__(
@@ -499,8 +531,14 @@ class ResBlock(nnx.Module):
       residual_size: int,
       hidden_size: Optional[int] = None,
       activation: Callable[[Array], Array] = nnx.relu,
+      layer_norm: str = 'nnx',
   ):
-    self.layernorm = nnx.LayerNorm(residual_size, rngs=rngs)
+    if layer_norm == 'nnx':
+      self.layernorm = nnx.LayerNorm(residual_size, rngs=rngs)
+    elif layer_norm == 'tensorflow':
+      self.layernorm = TensorFlowLayerNorm(residual_size, rngs=rngs)
+    else:
+      raise ValueError(f'Unknown layer norm type: {layer_norm}')
     self.linear1 = nnx.Linear(residual_size, hidden_size or residual_size, rngs=rngs)
     self.activation = activation
     # Initialize the output projection to zero so resnet starts as identity
@@ -532,6 +570,8 @@ class TransformerLike(Sequential, BuildableNetwork[Array, Array]):
         ffw_multiplier=4,
         recurrent_layer='lstm',
         activation='gelu',
+        gelu_approximate=True,
+        layer_norm='nnx',
     )
 
   def __init__(
@@ -543,6 +583,8 @@ class TransformerLike(Sequential, BuildableNetwork[Array, Array]):
       ffw_multiplier: int,
       recurrent_layer: str,
       activation: str,
+      gelu_approximate: bool = True,
+      layer_norm: str = 'nnx',
       remat: bool = False,
   ):
     self._hidden_size = hidden_size
@@ -556,7 +598,7 @@ class TransformerLike(Sequential, BuildableNetwork[Array, Array]):
 
     activation_fn = dict(
         relu=nnx.relu,
-        gelu=nnx.gelu,
+        gelu=lambda x: nnx.gelu(x, approximate=gelu_approximate),
         tanh=nnx.tanh,
     )[activation]
 
@@ -573,7 +615,8 @@ class TransformerLike(Sequential, BuildableNetwork[Array, Array]):
 
       ffw_layer = ResBlock(
           rngs, hidden_size, hidden_size * ffw_multiplier,
-          activation=activation_fn)
+          activation=activation_fn,
+          layer_norm=layer_norm)
       layers.append(FFWWrapper(ffw_layer, output_size=hidden_size))
 
     if remat:

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -460,8 +460,6 @@ def run(config: Config):
         raise ValueError(
             f'num_envs={config.actor.num_envs} must be divisible by '
             f'inner_batch_size={config.actor.inner_batch_size} for sim RL.')
-      if config.actor.num_env_steps:
-        raise ValueError('actor.num_env_steps is not used by sim async envs.')
     if config.agent.batch_steps > policy.delay:
       raise ValueError(
           f'agent.batch_steps={config.agent.batch_steps} exceeds policy delay '

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -453,10 +453,15 @@ def run(config: Config):
   )
 
   if config.actor.use_sim_envs:
-    if config.actor.async_envs:
-      raise ValueError('Sim envs are single-process; async_envs is not supported.')
     if config.opponent.type == OpponentType.CPU:
       raise ValueError('Sim env only supports AI-vs-AI opponents.')
+    if config.actor.async_envs:
+      if config.actor.num_envs % config.actor.inner_batch_size:
+        raise ValueError(
+            f'num_envs={config.actor.num_envs} must be divisible by '
+            f'inner_batch_size={config.actor.inner_batch_size} for sim RL.')
+      if config.actor.num_env_steps:
+        raise ValueError('actor.num_env_steps is not used by sim async envs.')
     if config.agent.batch_steps > policy.delay:
       raise ValueError(
           f'agent.batch_steps={config.agent.batch_steps} exceeds policy delay '
@@ -480,6 +485,8 @@ def run(config: Config):
           rollout_length=config.actor.rollout_length,
           batch_steps=config.agent.batch_steps,
           use_fake_envs=config.actor.use_fake_envs,
+          async_envs=config.actor.async_envs,
+          inner_batch_size=config.actor.inner_batch_size,
       )
 
   learner_manager = LearnerManager(

--- a/slippi_ai/jax/rl/run_lib.py
+++ b/slippi_ai/jax/rl/run_lib.py
@@ -24,6 +24,7 @@ from slippi_ai import (
 from slippi_ai.jax import saving as jax_saving
 from slippi_ai.jax import train_lib as train_lib
 from slippi_ai.jax.rl import learner as learner_lib
+from slippi_ai.sim_env import jax_rollout
 from slippi_ai.types import Game
 
 field = lambda f: dataclasses.field(default_factory=f)
@@ -265,7 +266,12 @@ def concise_name(name: str) -> str:
 
 def reset_optimizer_steps(imitation_state: dict):
   for key in ['policy_optimizer', 'value_optimizer']:
-    imitation_state['state'][key]['step'] = 0
+    if key in imitation_state['state']:
+      imitation_state['state'][key]['step'] = 0
+    else:
+      logging.warning(
+          'Imitation checkpoint is missing %s state; using a fresh optimizer.',
+          key)
 
 
 def run(config: Config):
@@ -436,14 +442,6 @@ def run(config: Config):
         inner_batch_size=config.actor.inner_batch_size,
     )
 
-  if config.actor.use_sim_envs:
-    if config.actor.use_fake_envs:
-      raise ValueError('use_sim_envs and use_fake_envs are mutually exclusive.')
-    if config.actor.async_envs:
-      raise ValueError('Sim envs are single-process; async_envs is not supported.')
-    if config.opponent.type == OpponentType.CPU:
-      raise ValueError('Sim env only supports AI-vs-AI opponents.')
-
   build_actor = lambda: evaluators.RolloutWorker(
       agent_kwargs=agent_kwargs,
       dolphin_kwargs=dolphin_kwargs,
@@ -452,8 +450,37 @@ def run(config: Config):
       async_envs=config.actor.async_envs,
       use_gpu=config.actor.gpu_inference,
       use_fake_envs=config.actor.use_fake_envs,
-      use_sim_envs=config.actor.use_sim_envs,
   )
+
+  if config.actor.use_sim_envs:
+    if config.actor.async_envs:
+      raise ValueError('Sim envs are single-process; async_envs is not supported.')
+    if config.opponent.type == OpponentType.CPU:
+      raise ValueError('Sim env only supports AI-vs-AI opponents.')
+    if config.agent.batch_steps > policy.delay:
+      raise ValueError(
+          f'agent.batch_steps={config.agent.batch_steps} exceeds policy delay '
+          f'{policy.delay} for sim RL.')
+    if config.actor.rollout_length % max(1, config.agent.batch_steps):
+      raise ValueError('agent.batch_steps must divide rollout_length for sim RL.')
+
+    def build_actor():
+      opponent_policy = None
+      train_opponent = config.opponent.should_train()
+      if not train_opponent:
+        opponent_policy = jax_saving.load_policy_from_state(
+            agent_kwargs[ENEMY_PORT]['state'])
+      return jax_rollout.JaxSimRolloutWorker(
+          policy=learner.policy,
+          opponent_policy=opponent_policy,
+          train_opponent=train_opponent,
+          agent_kwargs=agent_kwargs,
+          dolphin_kwargs=dolphin_kwargs,
+          num_envs=config.actor.num_envs,
+          rollout_length=config.actor.rollout_length,
+          batch_steps=config.agent.batch_steps,
+          use_fake_envs=config.actor.use_fake_envs,
+      )
 
   learner_manager = LearnerManager(
       config=config,

--- a/slippi_ai/reward.py
+++ b/slippi_ai/reward.py
@@ -147,9 +147,7 @@ def compute_rewards(
   def player_reward(player: Player, opponent: Player):
     reward = compute_base_reward(player)
 
-    if nana_ratio != 0:
-      if player.nana == ():
-        raise ValueError("Nana data is required for nana_ratio != 0")
+    if nana_ratio != 0 and player.nana != ():
       nana_reward = nana_ratio * compute_base_reward(player.nana)
       nana_reward = np.where(player.nana.exists[1:], nana_reward, 0)
       reward += nana_reward

--- a/slippi_ai/sim_env/__init__.py
+++ b/slippi_ai/sim_env/__init__.py
@@ -8,6 +8,7 @@ from slippi_ai.sim_env.env import (
     SimStepInfo,
     neutral_controllers,
 )
+from slippi_ai.sim_env.multiprocess_env import MultiprocessSimEnvironment
 from slippi_ai.sim_env.observations import GameBatch
 
 __all__ = (
@@ -16,6 +17,7 @@ __all__ = (
     'CharacterPool',
     'Controllers',
     'GameBatch',
+    'MultiprocessSimEnvironment',
     'Port',
     'SimBatchedEnvironment',
     'SimStepInfo',

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -228,11 +228,21 @@ class SimBatchedEnvironment:
       self,
       game_batch: GameBatchBuffers,
       needs_reset: np.ndarray | None = None,
+      *,
+      env_slice: slice | None = None,
+      controller_slice: slice | None = None,
   ):
     """Write the current sim observation into reusable policy input buffers."""
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
-    game_batch.fill(
-        self._env.current_frame, needs_reset, self._last_controllers)
+    if env_slice is None:
+      env_slice = slice(0, self._num_envs)
+    game_batch.fill_slice(
+        self._env.current_frame,
+        needs_reset,
+        env_slice,
+        self._last_controllers,
+        controller_slice=controller_slice,
+    )
 
   def reset(self, env_ids: tp.Sequence[int] | np.ndarray | None = None) -> EnvOutput:
     ids = np.arange(self._num_envs, dtype=np.int64) if env_ids is None else np.asarray(env_ids, dtype=np.int64)
@@ -348,6 +358,10 @@ class SimBatchedEnvironment:
   @property
   def last_step_info(self) -> SimStepInfo:
     return self._last_step_info
+
+  @property
+  def episode_ids(self) -> np.ndarray:
+    return self._episode_ids
 
   def pop_completed_games(self) -> list[dict[str, tp.Any]]:
     completed_games = self._completed_games

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -272,6 +272,25 @@ class SimBatchedEnvironment:
       shoulder_spacing: int,
   ) -> np.ndarray:
     """Step from encoded default-controller buckets shaped by port perspective."""
+    return self.step_encoded_slices(
+        controller_state,
+        player_slices=(
+            slice(0, self._num_envs),
+            slice(self._num_envs, 2 * self._num_envs),
+        ),
+        axis_spacing=axis_spacing,
+        shoulder_spacing=shoulder_spacing,
+    )
+
+  def step_encoded_slices(
+      self,
+      controller_state: Controller,
+      *,
+      player_slices: tuple[slice, slice],
+      axis_spacing: int,
+      shoulder_spacing: int,
+  ) -> np.ndarray:
+    """Step from encoded controller buckets with explicit source slices."""
     self._ensure_cursor_room()
 
     action = self._env.current_action_frame
@@ -281,7 +300,7 @@ class SimBatchedEnvironment:
         action,
         controller_state,
         player_index=0,
-        source_slice=slice(0, self._num_envs),
+        source_slice=player_slices[0],
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )
@@ -289,21 +308,21 @@ class SimBatchedEnvironment:
         action,
         controller_state,
         player_index=1,
-        source_slice=slice(self._num_envs, 2 * self._num_envs),
+        source_slice=player_slices[1],
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )
     copy_encoded_controller(
         self._last_controllers[1],
         controller_state,
-        source_slice=slice(0, self._num_envs),
+        source_slice=player_slices[0],
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )
     copy_encoded_controller(
         self._last_controllers[2],
         controller_state,
-        source_slice=slice(self._num_envs, 2 * self._num_envs),
+        source_slice=player_slices[1],
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -54,23 +54,6 @@ _CHARACTER_BY_NAME = {
     character.name.lower(): character for character in SUPPORTED_CHARACTERS
 }
 
-_TERMINAL_DTYPE = np.dtype(
-    [
-        ('frame_id', '<i4'),
-        ('stage_id', '<u4'),
-        ('done', 'u1'),
-        ('match_ended', 'u1'),
-        ('stockout', 'u1'),
-        ('max_frame_reached', 'u1'),
-        ('alive_count', 'u1'),
-        ('alive_team_count', 'u1'),
-        ('team_alive_mask', 'u1'),
-        ('_pad0', 'u1'),
-    ],
-    align=False,
-)
-
-
 class SimStepInfo(tp.NamedTuple):
   terminal: np.ndarray
   step_t: int
@@ -183,17 +166,16 @@ class SimBatchedEnvironment:
         for stage, char_pair in zip(self._stage_by_env, character_assignments)
     ]
 
-    # Native buffers own the rollout ring. Python keeps views into them and only
-    # writes controller actions / reads observations at the current cursor.
+    # EnvBatch owns and binds its native rollout ring. Python keeps views into
+    # that storage and only writes controller actions / reads observations at
+    # the current cursor.
     self._env = melee_sim.EnvBatch(
         batch_size=self._num_envs,
         length=self._frame_buffer_length,
         num_players=2,
         data_dir=data_dir,
     )
-    self._buffers = self._env.buffers(action_format='controller')
-    self._env.configure_matches(self._buffers, match_configs)
-    self._env.bind(self._buffers)
+    self._env.configure_matches(match_configs)
     self._env.reset_all()
 
     # Previous-controller observations are policy-visible, so they live beside
@@ -203,7 +185,7 @@ class SimBatchedEnvironment:
     }
 
     self._last_step_info = SimStepInfo(
-        terminal=np.zeros(self._num_envs, dtype=_TERMINAL_DTYPE),
+        terminal=np.zeros(self._num_envs, dtype=melee_sim.terminal_dtype()),
         step_t=-1,
     )
     self._episode_ids = np.zeros(self._num_envs, dtype=np.int64)
@@ -229,10 +211,10 @@ class SimBatchedEnvironment:
 
   def current_state(self, needs_reset: np.ndarray | None = None) -> EnvOutput:
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
-    frame = self._buffers.gamestate_view[self._env.t]
     return EnvOutput(
         gamestates={
-            port: game_for_port(frame, port, self._last_controllers)
+            port: game_for_port(
+                self._env.current_frame, port, self._last_controllers)
             for port in self._ports
         },
         needs_reset=np.asarray(needs_reset, dtype=np.bool_),
@@ -241,10 +223,10 @@ class SimBatchedEnvironment:
   def current_game_batch(self, needs_reset: np.ndarray | None = None) -> GameBatch:
     """Return a [port1 views, port2 views] game batch for policy calls."""
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
-    frame = self._buffers.gamestate_view[self._env.t]
     # Reuse one Game nest and mutate its leaves. This is the high-throughput
     # adapter path from melee_sim's native buffers to the JAX policy input.
-    self._game_batch.fill(frame, needs_reset, self._last_controllers)
+    self._game_batch.fill(
+        self._env.current_frame, needs_reset, self._last_controllers)
     return GameBatch(
         game=self._game_batch.game,
         needs_reset=self._game_batch.needs_reset,
@@ -255,11 +237,11 @@ class SimBatchedEnvironment:
     if np.any(ids < 0) or np.any(ids >= self._num_envs):
       raise ValueError('env_ids contains an out-of-range env index')
     self._ensure_cursor_room()
-    reset_mask = self._buffers.reset_mask
-    reset_mask[self._env.t, :] = 0
-    reset_mask[self._env.t, ids] = 1
+    reset_mask = self._env.current_reset_mask
+    reset_mask[:] = 0
+    reset_mask[ids] = 1
     self._env.reset_masked()
-    reset_mask[self._env.t, ids] = 0
+    reset_mask[ids] = 0
     self._episode_ids[ids] += 1
     if ids.size:
       neutral = neutral_controllers(ids.size)
@@ -292,7 +274,7 @@ class SimBatchedEnvironment:
     """Step from encoded default-controller buckets shaped by port perspective."""
     self._ensure_cursor_room()
 
-    action = self._buffers.controller_action_view[self._env.t]
+    action = self._env.current_action_frame
     # Decode policy buckets straight into the native action ring, and mirror the
     # same decoded values into previous-controller state for the next Game view.
     write_encoded_controller_action(
@@ -330,10 +312,10 @@ class SimBatchedEnvironment:
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
-    needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
-    terminal = terminal_view(self._buffers)[step_t].copy()
+    needs_reset = self._env.done_at(step_t).astype(np.bool_, copy=True)
+    terminal = self._env.terminal_at(step_t).copy()
     self._last_step_info = SimStepInfo(terminal=terminal, step_t=step_t)
-    self._record_completed_games(terminal, self._buffers.gamestate_view[self._env.t])
+    self._record_completed_games(terminal, self._env.current_frame)
     self._reset_finished_lanes_for_next_observation(needs_reset)
     return needs_reset
 
@@ -342,7 +324,7 @@ class SimBatchedEnvironment:
 
   @property
   def buffers(self):
-    return self._buffers
+    return self._env.buffers
 
   @property
   def cursor(self) -> int:
@@ -375,7 +357,7 @@ class SimBatchedEnvironment:
   def _advance(self, controllers: Controllers) -> EnvOutput:
     self._ensure_cursor_room()
 
-    action = self._buffers.controller_action_view[self._env.t]
+    action = self._env.current_action_frame
     for player_index, port in enumerate(self._ports):
       controller = controllers[port]
       player = action['p'][:, int(player_index)]
@@ -397,10 +379,10 @@ class SimBatchedEnvironment:
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
-    needs_reset = self._buffers.done[step_t].astype(np.bool_, copy=True)
-    terminal = terminal_view(self._buffers)[step_t].copy()
+    needs_reset = self._env.done_at(step_t).astype(np.bool_, copy=True)
+    terminal = self._env.terminal_at(step_t).copy()
     self._last_step_info = SimStepInfo(terminal=terminal, step_t=step_t)
-    self._record_completed_games(terminal, self._buffers.gamestate_view[self._env.t])
+    self._record_completed_games(terminal, self._env.current_frame)
     self._reset_finished_lanes_for_next_observation(needs_reset)
     return self.current_state(needs_reset=needs_reset)
 
@@ -464,18 +446,6 @@ def neutral_controllers(batch_size: int) -> Controller:
           name: np.zeros(shape, dtype=np.bool_)
           for name in Buttons._fields
       }),
-  )
-
-
-def terminal_view(buffers: melee_sim.Buffers) -> np.ndarray:
-  """View the native terminal side-channel as a structured NumPy array."""
-  raw = buffers.terminal
-  if raw.shape[2] < _TERMINAL_DTYPE.itemsize:
-    raise ValueError('terminal buffer row is smaller than MslTerminal')
-  return (
-      raw[:, :, :_TERMINAL_DTYPE.itemsize]
-      .view(_TERMINAL_DTYPE)
-      .reshape(raw.shape[0], raw.shape[1])
   )
 
 

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -76,6 +76,7 @@ class SimStepInfo(tp.NamedTuple):
   step_t: int
 
 
+PlayerConfigs = tp.Mapping[int, dolphin.Player]
 CharacterPool = str | tp.Sequence[melee.Character | str | int]
 
 
@@ -91,31 +92,40 @@ class SimBatchedEnvironment:
   def __init__(
       self,
       num_envs: int,
-      players: tp.Mapping[int, dolphin.Player] | None = None,
+      players: PlayerConfigs | tp.Sequence[PlayerConfigs] | None = None,
       *,
       frame_buffer_length: int = 128,
       stage: melee.Stage | tp.Sequence[melee.Stage] = melee.Stage.FINAL_DESTINATION,
       character_pool: CharacterPool | None = None,
       max_frame_id: int = -1,
       data_dir: str | None = None,
+      fake: bool = False,
   ):
     self._num_envs = int(num_envs)
     self._frame_buffer_length = int(frame_buffer_length)
     self._max_frame_id = int(max_frame_id)
+    self._fake = fake
     self.num_steps = 1
 
     # The sim adapter currently exposes the singles shape used by the policy:
     # port 1 and port 2, no teams, one controlled character per port.
     if players is None:
-      self._players = {
+      default_players = {
           1: dolphin.AI(melee.Character.FOX),
           2: dolphin.AI(melee.Character.FOX),
       }
+      self._players_by_env = (default_players,) * self._num_envs
+    elif isinstance(players, collections.abc.Mapping):
+      self._players_by_env = (players,) * self._num_envs
     else:
-      self._players = players
+      self._players_by_env = tuple(players)
+      if len(self._players_by_env) != self._num_envs:
+        raise ValueError(f'players sequence must have length num_envs={self._num_envs}')
+    self._players = self._players_by_env[0]
     self._ports = tuple(sorted(self._players))
-    if self._ports != _SUPPORTED_PORTS:
-      raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
+    for player_map in self._players_by_env:
+      if tuple(sorted(player_map)) != _SUPPORTED_PORTS:
+        raise ValueError('SimBatchedEnvironment currently supports ports 1 and 2.')
 
     # `stage` can be one value for every lane or an explicit per-env list.
     if isinstance(stage, melee.Stage):
@@ -129,17 +139,18 @@ class SimBatchedEnvironment:
         raise ValueError(f'SimBatchedEnvironment currently supports {SUPPORTED_STAGES}.')
     self._stage_by_env = np.asarray(stages, dtype=object)
 
-    # Default to the explicit player matchup everywhere. If a pool is supplied,
-    # cycle lanes through the ordered singles matchup matrix. Resets keep each
-    # lane's initial matchup until we intentionally add randomized reset-time
-    # assignment later.
+    # Default to the explicit player matchup for each lane. If a pool is
+    # supplied, cycle lanes through the ordered singles matchup matrix. Resets
+    # keep each lane's initial matchup until we intentionally add randomized
+    # reset-time assignment later.
     if character_pool is None:
-      character_assignments = (
+      character_assignments = tuple(
           (
-              _coerce_character(self._players[1].character),
-              _coerce_character(self._players[2].character),
-          ),
-      ) * self._num_envs
+              _coerce_character(player_map[1].character),
+              _coerce_character(player_map[2].character),
+          )
+          for player_map in self._players_by_env
+      )
     else:
       if isinstance(character_pool, str):
         characters = tuple(
@@ -314,6 +325,8 @@ class SimBatchedEnvironment:
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
     )
+    if self._fake:
+      return np.zeros(self._num_envs, dtype=np.bool_)
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)
@@ -379,6 +392,8 @@ class SimBatchedEnvironment:
           slice(None),
           slice(None),
       )
+    if self._fake:
+      return self.current_state(needs_reset=np.zeros(self._num_envs, dtype=np.bool_))
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -282,6 +282,10 @@ class SimBatchedEnvironment:
         shoulder_spacing=shoulder_spacing,
     )
 
+  # The JAX rollout worker stores both port perspectives in one controller
+  # batch. Multiprocess workers own contiguous env shards, so they pass the
+  # source slices for port 1 and port 2 explicitly instead of assuming the
+  # default [all p1 views, all p2 views] layout.
   def step_encoded_slices(
       self,
       controller_state: Controller,
@@ -296,36 +300,22 @@ class SimBatchedEnvironment:
     action = self._env.current_action_frame
     # Decode policy buckets straight into the native action ring, and mirror the
     # same decoded values into previous-controller state for the next Game view.
-    write_encoded_controller_action(
-        action,
-        controller_state,
-        player_index=0,
-        source_slice=player_slices[0],
-        axis_spacing=axis_spacing,
-        shoulder_spacing=shoulder_spacing,
-    )
-    write_encoded_controller_action(
-        action,
-        controller_state,
-        player_index=1,
-        source_slice=player_slices[1],
-        axis_spacing=axis_spacing,
-        shoulder_spacing=shoulder_spacing,
-    )
-    copy_encoded_controller(
-        self._last_controllers[1],
-        controller_state,
-        source_slice=player_slices[0],
-        axis_spacing=axis_spacing,
-        shoulder_spacing=shoulder_spacing,
-    )
-    copy_encoded_controller(
-        self._last_controllers[2],
-        controller_state,
-        source_slice=player_slices[1],
-        axis_spacing=axis_spacing,
-        shoulder_spacing=shoulder_spacing,
-    )
+    for player_index, port in enumerate(self._ports):
+      write_encoded_controller_action(
+          action,
+          controller_state,
+          player_index=player_index,
+          source_slice=player_slices[player_index],
+          axis_spacing=axis_spacing,
+          shoulder_spacing=shoulder_spacing,
+      )
+      copy_encoded_controller(
+          self._last_controllers[port],
+          controller_state,
+          source_slice=player_slices[player_index],
+          axis_spacing=axis_spacing,
+          shoulder_spacing=shoulder_spacing,
+      )
     if self._fake:
       return np.zeros(self._num_envs, dtype=np.bool_)
 

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -284,7 +284,7 @@ class SimBatchedEnvironment:
       shoulder_spacing: int,
       output_game_batch: GameBatchBuffers | None = None,
   ) -> np.ndarray:
-    """Step from encoded default-controller buckets shaped by port perspective."""
+    """Step encoded actions and optionally write the post-step observation."""
     return self.step_encoded_slices(
         controller_state,
         player_slices=(
@@ -332,7 +332,10 @@ class SimBatchedEnvironment:
           shoulder_spacing=shoulder_spacing,
       )
     if self._fake:
-      return np.zeros(self._num_envs, dtype=np.bool_)
+      needs_reset = np.zeros(self._num_envs, dtype=np.bool_)
+      if output_game_batch is not None:
+        self.write_current_game(output_game_batch, needs_reset)
+      return needs_reset
 
     step_t = self._env.t
     self._env.step(max_frame_id=self._max_frame_id)

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -282,6 +282,7 @@ class SimBatchedEnvironment:
       *,
       axis_spacing: int,
       shoulder_spacing: int,
+      output_game_batch: GameBatchBuffers | None = None,
   ) -> np.ndarray:
     """Step from encoded default-controller buckets shaped by port perspective."""
     return self.step_encoded_slices(
@@ -292,6 +293,7 @@ class SimBatchedEnvironment:
         ),
         axis_spacing=axis_spacing,
         shoulder_spacing=shoulder_spacing,
+        output_game_batch=output_game_batch,
     )
 
   # The JAX rollout worker stores both port perspectives in one controller
@@ -305,6 +307,7 @@ class SimBatchedEnvironment:
       player_slices: tuple[slice, slice],
       axis_spacing: int,
       shoulder_spacing: int,
+      output_game_batch: GameBatchBuffers | None = None,
   ) -> np.ndarray:
     """Step from encoded controller buckets with explicit source slices."""
     self._ensure_cursor_room()
@@ -338,6 +341,8 @@ class SimBatchedEnvironment:
     self._last_step_info = SimStepInfo(terminal=terminal, step_t=step_t)
     self._record_completed_games(terminal, self._env.current_frame)
     self._reset_finished_lanes_for_next_observation(needs_reset)
+    if output_game_batch is not None:
+      self.write_current_game(output_game_batch, needs_reset)
     return needs_reset
 
   def multi_step(self, controllers: list[Controllers]) -> list[EnvOutput]:

--- a/slippi_ai/sim_env/env.py
+++ b/slippi_ai/sim_env/env.py
@@ -8,7 +8,7 @@ the libmelee-shaped observation nest.
 
 There are two use modes. `current_state`/`step` preserve the familiar
 port-keyed Dolphin env interface for tests and small tools. The high-throughput
-path uses `current_game_batch` and `step_encoded`: one reusable `GameBatch`
+path uses `write_current_game` and `step_encoded`: one reusable `GameBatch`
 stores all port-1 perspectives followed by all port-2 perspectives, and policy
 action buckets are decoded straight into the native action ring. That path avoids
 rebuilding Python game objects during rollout and is what the JAX sim pipeline
@@ -27,8 +27,8 @@ import numpy as np
 from slippi_ai import dolphin
 from slippi_ai.envs import EnvOutput
 from slippi_ai.sim_env.observations import (
-    GameBatch, GameBatchBuffers,
-    copy_controller_slice as _copy_controller_slice, game_for_port,
+    GameBatchBuffers, copy_controller_slice as _copy_controller_slice,
+    game_for_port,
 )
 from slippi_ai.types import Buttons, Controller, Stick
 
@@ -68,7 +68,7 @@ class SimBatchedEnvironment:
 
   The public env shape mirrors the Dolphin-backed envs: callers pass controller
   actions and receive `EnvOutput` objects. High-throughput paths should use
-  `current_game_batch` and `step_encoded` to avoid rebuilding per-port Python
+  `write_current_game` and `step_encoded` to avoid rebuilding per-port Python
   objects while still feeding the same policy-facing fields.
   """
 
@@ -220,17 +220,19 @@ class SimBatchedEnvironment:
         needs_reset=np.asarray(needs_reset, dtype=np.bool_),
     )
 
-  def current_game_batch(self, needs_reset: np.ndarray | None = None) -> GameBatch:
-    """Return a [port1 views, port2 views] game batch for policy calls."""
+  @property
+  def game_batch_buffers(self) -> GameBatchBuffers:
+    return self._game_batch
+
+  def write_current_game(
+      self,
+      game_batch: GameBatchBuffers,
+      needs_reset: np.ndarray | None = None,
+  ):
+    """Write the current sim observation into reusable policy input buffers."""
     needs_reset = np.zeros(self._num_envs, dtype=np.bool_) if needs_reset is None else needs_reset
-    # Reuse one Game nest and mutate its leaves. This is the high-throughput
-    # adapter path from melee_sim's native buffers to the JAX policy input.
-    self._game_batch.fill(
+    game_batch.fill(
         self._env.current_frame, needs_reset, self._last_controllers)
-    return GameBatch(
-        game=self._game_batch.game,
-        needs_reset=self._game_batch.needs_reset,
-    )
 
   def reset(self, env_ids: tp.Sequence[int] | np.ndarray | None = None) -> EnvOutput:
     ids = np.arange(self._num_envs, dtype=np.int64) if env_ids is None else np.asarray(env_ids, dtype=np.int64)

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -46,6 +46,8 @@ class JaxSimRolloutWorker:
       opponent_policy: policies.Policy | None = None,
       train_opponent: bool = True,
       use_fake_envs: bool = False,
+      async_envs: bool = False,
+      inner_batch_size: int = 1,
   ):
     self._num_envs = int(num_envs)
     self._num_players = self._num_envs * len(self.ports)
@@ -131,6 +133,8 @@ class JaxSimRolloutWorker:
         int(controller_config['shoulder_spacing']),
     )
     self._batch_steps = max(1, int(batch_steps))
+    self._async_envs = bool(async_envs)
+    self._inner_batch_size = int(inner_batch_size)
     self._env_kwargs = dict(
         num_envs=self._num_envs,
         players=[kwargs['players'] for kwargs in dolphin_kwargs],
@@ -361,6 +365,11 @@ class JaxSimRolloutWorker:
     }
 
   def _build_env(self):
+    if self._async_envs:
+      return sim_env.MultiprocessSimEnvironment(
+          **self._env_kwargs,
+          inner_batch_size=self._inner_batch_size,
+      )
     return sim_env.SimBatchedEnvironment(**self._env_kwargs)
 
 
@@ -468,7 +477,7 @@ def _replay_delayed_controller_queue(
     if np.any(reset_mask):
       _reset_delayed_controller_queue(queue, neutral_controller, reset_mask)
     controller = jax.tree.map(
-        lambda x: np.asarray(x[int(index)]).copy(),
+        lambda x: np.asarray(x[index]).copy(),
         sample_outputs.controller_state,
     )
     queue.append(controller)

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -356,7 +356,7 @@ class JaxSimRolloutWorker:
             port: timings[f'agent_step_{port}'] / max(num_steps, 1)
             for port in self.ports
         },
-        'trajectory_build': timings['trajectory_build'],
+        'trajectory_build': timings['trajectory_build'] / max(num_steps, 1),
     }
     return trajectories, {
         'timing': timing,

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -1,4 +1,4 @@
-"""JAX rollout assembly for single-process melee-sim-light envs.
+"""JAX rollout assembly for melee-sim-light envs.
 
 The generic evaluator path builds slippi-ai Game/controller Python objects once
 per port per frame. This worker uses
@@ -209,6 +209,8 @@ class JaxSimRolloutWorker:
           f'got rollout({num_steps}).')
     trajectory_buffers = self._trajectory_buffers
     reset_buffer = trajectory_buffers.needs_reset
+    # Rollout frame 0 starts from the env's current observation. In MP this is
+    # copied from the last written shared frame; in-process envs read MSL state.
     self._env.write_current_game(trajectory_buffers.frames[0], self._needs_reset)
     trajectory_actions = []
     initial_state = self.actor.hidden_state()

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -2,7 +2,7 @@
 
 The generic evaluator path builds slippi-ai Game/controller Python objects once
 per port per frame. This worker uses
-`SimBatchedEnvironment.current_game_batch()` and `step_encoded()` instead: one
+`SimBatchedEnvironment.write_current_game()` and `step_encoded()` instead: one
 reusable observation tree is filled from native sim buffers, JAX samples both
 port perspectives, and the resulting trajectory is split back into the port
 entries expected by the learner.
@@ -149,9 +149,10 @@ class JaxSimRolloutWorker:
     self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
     self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
         [self._num_players])
-    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._game_batch = self._env.game_batch_buffers
+    self._env.write_current_game(self._game_batch, self._needs_reset)
     self._state_buffer = _make_trajectory_state_buffer(
-        game_batch.game, self._rollout_length)
+        self._game_batch.game, self._rollout_length)
     self._reset_buffer = np.empty(
         (self._rollout_length + 1, self._num_players), dtype=np.bool_)
     self._reset_delay_queues()
@@ -187,9 +188,10 @@ class JaxSimRolloutWorker:
     self.stop()
     self._env = self._build_env()
     self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
-    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._game_batch = self._env.game_batch_buffers
+    self._env.write_current_game(self._game_batch, self._needs_reset)
     self._state_buffer = _make_trajectory_state_buffer(
-        game_batch.game, self._rollout_length)
+        self._game_batch.game, self._rollout_length)
     self._reset_delay_queues()
 
   def update_variables(self, updates):
@@ -212,7 +214,7 @@ class JaxSimRolloutWorker:
       raise ValueError(
           f'JaxSimRolloutWorker was built for rollout_length={self._rollout_length}, '
           f'got rollout({num_steps}).')
-    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._env.write_current_game(self._game_batch, self._needs_reset)
     state_buffer = self._state_buffer
     reset_buffer = self._reset_buffer
     trajectory_actions = []
@@ -239,7 +241,7 @@ class JaxSimRolloutWorker:
         t = chunk_start + local_t
         copy_start = time.perf_counter()
         _copy_state_slot(state_buffer, t)
-        reset_buffer[t] = game_batch.needs_reset
+        reset_buffer[t] = self._game_batch.needs_reset
         timings['state_copy'] += time.perf_counter() - copy_start
 
         reset_mask = reset_buffer[t]
@@ -261,7 +263,7 @@ class JaxSimRolloutWorker:
             axis_spacing=self._controller_spacing[0],
             shoulder_spacing=self._controller_spacing[1],
         )
-        game_batch = self._env.current_game_batch(self._needs_reset)
+        self._env.write_current_game(self._game_batch, self._needs_reset)
         timings['env_step'] += time.perf_counter() - env_start
 
       if self._opponent_actor is None:
@@ -322,7 +324,7 @@ class JaxSimRolloutWorker:
     # trees expected by the existing PPO path.
     copy_start = time.perf_counter()
     _copy_state_slot(state_buffer, num_steps)
-    reset_buffer[num_steps] = game_batch.needs_reset
+    reset_buffer[num_steps] = self._game_batch.needs_reset
     trajectory_actions.append(self._delayed_outputs_queue[0])
     timings['state_copy'] += time.perf_counter() - copy_start
 
@@ -375,7 +377,7 @@ class JaxSimRolloutWorker:
 class _TrajectoryStateBuffer(tp.NamedTuple):
   """Time-major storage for T+1 policy observations.
 
-  `current_game_batch()` reuses one mutable Game tree, while the learner needs
+  `write_current_game()` reuses one mutable Game tree, while the learner needs
   the whole rollout after the sim has advanced. `slots` are NumPy views into the
   time-major `states` tree, so copying into a slot writes directly into the
   corresponding frame of the final trajectory buffer.

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -1,0 +1,500 @@
+"""JAX rollout assembly for single-process melee-sim-light envs.
+
+The generic evaluator path builds slippi-ai Game/controller Python objects once
+per port per frame. This worker uses
+`SimBatchedEnvironment.current_game_batch()` and `step_encoded()` instead: one
+reusable observation tree is filled from native sim buffers, JAX samples both
+port perspectives, and the resulting trajectory is split back into the port
+entries expected by the learner.
+"""
+
+import collections
+import contextlib
+import itertools
+import time
+import typing as tp
+
+import jax
+import melee
+import numpy as np
+
+from slippi_ai import eval_lib
+from slippi_ai import reward
+from slippi_ai import sim_env
+from slippi_ai import utils
+from slippi_ai.controller_heads import SampleOutputs
+from slippi_ai.data import NAME_DTYPE
+from slippi_ai.evaluators import Port, Timings, Trajectory
+from slippi_ai.jax import policies
+from slippi_ai.types import Game
+
+
+class JaxSimRolloutWorker:
+  """RolloutWorker-compatible adapter for JAX policies on one sim batch."""
+
+  ports: tuple[Port, Port] = (1, 2)
+
+  def __init__(
+      self,
+      *,
+      policy: policies.Policy,
+      agent_kwargs: tp.Mapping[int, dict],
+      dolphin_kwargs: tp.Union[dict, tp.Sequence[dict]],
+      num_envs: int,
+      rollout_length: int,
+      batch_steps: int = 1,
+      opponent_policy: policies.Policy | None = None,
+      train_opponent: bool = True,
+      use_fake_envs: bool = False,
+  ):
+    self._num_envs = int(num_envs)
+    self._num_players = self._num_envs * len(self.ports)
+    self._rollout_length = int(rollout_length)
+    self._batch_slice_by_port = {
+        port: slice(i * self._num_envs, (i + 1) * self._num_envs)
+        for i, port in enumerate(self.ports)
+    }
+    self._train_ports = self.ports if train_opponent else (1,)
+    if isinstance(dolphin_kwargs, dict):
+      dolphin_kwargs = [dolphin_kwargs.copy() for _ in range(self._num_envs)]
+    elif self._num_envs != len(dolphin_kwargs):
+      raise ValueError(
+          f'num_envs={self._num_envs} does not match '
+          f'{len(dolphin_kwargs)} dolphin kwargs entries.')
+    else:
+      dolphin_kwargs = list(dolphin_kwargs)
+
+    agent1_kwargs = agent_kwargs[1]
+    agent2_kwargs = agent_kwargs[2]
+
+    should_compile = agent1_kwargs['compile']
+    state = agent1_kwargs['state']
+    name_code_by_port = {
+        port: np.asarray(
+            eval_lib.get_name_codes(
+                kwargs['state'],
+                kwargs['name'],
+                batch_size=self._num_envs,
+            ),
+            dtype=NAME_DTYPE,
+        )
+        for port, kwargs in ((1, agent1_kwargs), (2, agent2_kwargs))
+    }
+    self._name_code = np.concatenate(
+        [name_code_by_port[port] for port in self.ports], axis=0)
+
+    # Same-policy self-play gets one actor over [port1 views, port2 views].
+    # Fixed-opponent rollout keeps that same env/action layout, but samples the
+    # two halves with separate policy objects and concatenates the outputs.
+    if opponent_policy is None:
+      self.actor = policy.build_agent(
+          batch_size=self._num_players,
+          name_code=self._name_code,
+          compile=should_compile,
+          pack_args=True,
+      )
+      self._opponent_actor = None
+    else:
+      self.actor = policy.build_agent(
+          batch_size=self._num_envs,
+          name_code=name_code_by_port[1],
+          compile=should_compile,
+          pack_args=True,
+      )
+      self._opponent_actor = opponent_policy.build_agent(
+          batch_size=self._num_envs,
+          name_code=name_code_by_port[2],
+          compile=agent2_kwargs['compile'],
+          pack_args=True,
+      )
+
+    # Translate the Dolphin-style environment config into the smaller sim env
+    # config. The sim path still accepts the same high-level launch config as
+    # the generic rollout worker.
+    dolphin_kwargs_0 = dolphin_kwargs[0]
+    stages = [kwargs['stage'] for kwargs in dolphin_kwargs]
+    if any(stage is melee.Stage.RANDOM_STAGE for stage in stages):
+      stages = list(itertools.islice(
+          itertools.cycle(sim_env.SUPPORTED_STAGES),
+          self._num_envs,
+      ))
+
+    controller_config = state['config']['embed']['controller']
+    other_config = agent2_kwargs['state']['config']['embed']['controller']
+    if other_config != controller_config:
+      raise ValueError('JAX sim rollout requires matching controller configs.')
+    if controller_config['type'] != 'default':
+      raise ValueError('sim env only supports the default controller embedding')
+    controller_config = controller_config['default']
+    self._controller_spacing = (
+        int(controller_config['axis_spacing']),
+        int(controller_config['shoulder_spacing']),
+    )
+    self._batch_steps = max(1, int(batch_steps))
+    self._env_kwargs = dict(
+        num_envs=self._num_envs,
+        players=[kwargs['players'] for kwargs in dolphin_kwargs],
+        stage=stages,
+        max_frame_id=(
+            -1 if dolphin_kwargs_0['infinite_time'] else 8 * 60 * 60 - 123),
+        fake=use_fake_envs,
+        frame_buffer_length=self._rollout_length + 1,
+    )
+
+    self._env = self._build_env()
+    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
+    self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
+        [self._num_players])
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._state_buffer = _make_trajectory_state_buffer(
+        game_batch.game, self._rollout_length)
+    self._reset_buffer = np.empty(
+        (self._rollout_length + 1, self._num_players), dtype=np.bool_)
+    self._reset_delay_queues()
+
+  def _reset_delay_queues(self):
+    # Keep one controller in the queue even when policy delay is 0; then the
+    # same queue update path covers both immediate and delayed control.
+    self._delayed_controller_queue = collections.deque(
+        [_copy_to_numpy_tree(self._dummy_outputs.controller_state)
+         for _ in range(self.actor._policy.delay + 1)])
+    self._delayed_outputs_queue = collections.deque(
+        [_copy_to_numpy_tree(self._dummy_outputs)
+         for _ in range(self.actor._policy.delay + 1)])
+
+  def start(self):
+    pass
+
+  @contextlib.contextmanager
+  def run(self):
+    try:
+      self.start()
+      yield
+    finally:
+      self.stop()
+
+  def stop(self):
+    self._env.stop()
+
+  def active_sim_games(self) -> list[dict[str, int | str]]:
+    return self._env.active_games()
+
+  def reset_env(self):
+    self.stop()
+    self._env = self._build_env()
+    self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    self._state_buffer = _make_trajectory_state_buffer(
+        game_batch.game, self._rollout_length)
+    self._reset_delay_queues()
+
+  def update_variables(self, updates):
+    if self._opponent_actor is None:
+      self.actor._policy.set_state(updates.get(1, updates.get(2)))
+      return
+    if 1 in updates:
+      self.actor._policy.set_state(updates[1])
+    if 2 in updates:
+      self._opponent_actor._policy.set_state(updates[2])
+
+  def rollout(
+      self,
+      num_steps: int,
+      verbose: bool = False,
+  ) -> tuple[tp.Mapping[Port, Trajectory], Timings]:
+    del verbose
+    timings: dict[str, float] = collections.defaultdict(float)
+    num_steps = int(num_steps)
+    if num_steps != self._rollout_length:
+      raise ValueError(
+          f'JaxSimRolloutWorker was built for rollout_length={self._rollout_length}, '
+          f'got rollout({num_steps}).')
+    game_batch = self._env.current_game_batch(self._needs_reset)
+    state_buffer = self._state_buffer
+    reset_buffer = self._reset_buffer
+    trajectory_actions = []
+    initial_state = self.actor.hidden_state()
+    if self._opponent_actor is None:
+      initial_state_by_port = {
+          port: utils.map_single_structure(lambda x: x[batch_slice], initial_state)
+          for port, batch_slice in self._batch_slice_by_port.items()
+      }
+    else:
+      initial_state_by_port = {1: initial_state}
+
+    # Step the sim immediately with already-delayed controller inputs, while
+    # collecting a chunk of observations for one fused JAX actor call.
+    for chunk_start in range(0, num_steps, self._batch_steps):
+      # `chunk_len` is normally `_batch_steps`; it is shorter only for a final
+      # partial chunk when num_steps is not divisible by batch_steps.
+      chunk_len = min(self._batch_steps, num_steps - chunk_start)
+      chunk_inputs = []
+      chunk_reset_masks = []
+      controller_queue_start = list(self._delayed_controller_queue)
+
+      for local_t in range(chunk_len):
+        t = chunk_start + local_t
+        copy_start = time.perf_counter()
+        _copy_state_slot(state_buffer, t)
+        reset_buffer[t] = game_batch.needs_reset
+        timings['state_copy'] += time.perf_counter() - copy_start
+
+        reset_mask = reset_buffer[t]
+        chunk_inputs.append((state_buffer.slots[t], reset_mask))
+        chunk_reset_masks.append(reset_mask)
+        if np.any(reset_mask):
+          _reset_delayed_controller_queue(
+              self._delayed_controller_queue,
+              self._dummy_outputs.controller_state,
+              reset_mask,
+          )
+
+        delayed_controller = self._delayed_controller_queue.popleft()
+        trajectory_actions.append(self._delayed_outputs_queue.popleft())
+
+        env_start = time.perf_counter()
+        self._needs_reset = self._env.step_encoded(
+            delayed_controller,
+            axis_spacing=self._controller_spacing[0],
+            shoulder_spacing=self._controller_spacing[1],
+        )
+        game_batch = self._env.current_game_batch(self._needs_reset)
+        timings['env_step'] += time.perf_counter() - env_start
+
+      if self._opponent_actor is None:
+        step_start = time.perf_counter()
+        chunk_outputs = _sample_chunk(self.actor, chunk_inputs)
+        # Pull the whole stacked chunk to host once. Later delayed-controller
+        # replay and trajectory assembly slice these arrays many times, and
+        # doing that slicing on JAX device arrays creates thousands of tiny ops.
+        chunk_outputs = jax.tree.map(np.asarray, chunk_outputs)
+        elapsed = time.perf_counter() - step_start
+        elapsed_per_port = elapsed / len(self.ports)
+        for port in self.ports:
+          timings[f'agent_step_{port}'] += elapsed_per_port
+      else:
+        main_inputs = [
+            (
+                utils.map_single_structure(
+                    lambda x: x[self._batch_slice_by_port[1]], game),
+                reset[self._batch_slice_by_port[1]],
+            )
+            for game, reset in chunk_inputs
+        ]
+        opponent_inputs = [
+            (
+                utils.map_single_structure(
+                    lambda x: x[self._batch_slice_by_port[2]], game),
+                reset[self._batch_slice_by_port[2]],
+            )
+            for game, reset in chunk_inputs
+        ]
+        main_start = time.perf_counter()
+        main_outputs = _sample_chunk(self.actor, main_inputs)
+        main_outputs = jax.tree.map(np.asarray, main_outputs)
+        timings['agent_step_1'] += time.perf_counter() - main_start
+
+        opponent_start = time.perf_counter()
+        opponent_outputs = _sample_chunk(self._opponent_actor, opponent_inputs)
+        opponent_outputs = jax.tree.map(np.asarray, opponent_outputs)
+        timings['agent_step_2'] += time.perf_counter() - opponent_start
+
+        chunk_outputs = jax.tree.map(
+            lambda a, b: np.concatenate([a, b], axis=1),
+            main_outputs,
+            opponent_outputs,
+        )
+      _replay_delayed_controller_queue(
+          self._delayed_controller_queue,
+          controller_queue_start,
+          chunk_outputs,
+          chunk_reset_masks,
+          self._dummy_outputs.controller_state,
+      )
+      for index in range(chunk_len):
+        self._delayed_outputs_queue.append(
+            jax.tree.map(lambda x, i=index: x[i], chunk_outputs))
+
+    # Capture the T+1 terminal observation and assemble the learner trajectory
+    # trees expected by the existing PPO path.
+    copy_start = time.perf_counter()
+    _copy_state_slot(state_buffer, num_steps)
+    reset_buffer[num_steps] = game_batch.needs_reset
+    trajectory_actions.append(self._delayed_outputs_queue[0])
+    timings['state_copy'] += time.perf_counter() - copy_start
+
+    build_start = time.perf_counter()
+    time_major_states = state_buffer.states
+    encoded_states = self.actor._policy.network.encode_game(time_major_states)
+    rewards = reward.compute_rewards(time_major_states)
+    batched_actions = _batch_actions(trajectory_actions)
+    delayed_actions = list(self._delayed_outputs_queue)[1:]
+    timings['trajectory_build'] = time.perf_counter() - build_start
+
+    trajectories = {}
+    for port, batch_slice in self._batch_slice_by_port.items():
+      if port not in self._train_ports:
+        continue
+      trajectories[port] = _trajectory_slice(
+          states=encoded_states,
+          actions=batched_actions,
+          rewards=rewards,
+          is_resetting=reset_buffer,
+          initial_state=initial_state_by_port[port],
+          delayed_actions=delayed_actions,
+          name_code=self._name_code,
+          batch_slice=batch_slice,
+      )
+    timing = {
+        'env_pop': timings['state_copy'] / max(num_steps, 1),
+        'env_push': timings['env_step'] / max(num_steps, 1),
+        'agent_step': {
+            port: timings[f'agent_step_{port}'] / max(num_steps, 1)
+            for port in self.ports
+        },
+        'trajectory_build': timings['trajectory_build'],
+    }
+    return trajectories, {
+        'timing': timing,
+        'unexpected_reset': reset_buffer[1:, :self._num_envs].copy(),
+        'completed_games': self._env.pop_completed_games(),
+    }
+
+  def _build_env(self):
+    return sim_env.SimBatchedEnvironment(**self._env_kwargs)
+
+
+class _TrajectoryStateBuffer(tp.NamedTuple):
+  """Time-major storage for T+1 policy observations.
+
+  `current_game_batch()` reuses one mutable Game tree, while the learner needs
+  the whole rollout after the sim has advanced. `slots` are NumPy views into the
+  time-major `states` tree, so copying into a slot writes directly into the
+  corresponding frame of the final trajectory buffer.
+  """
+
+  states: Game
+  slots: list[Game]
+  slot_leaves: list[tuple]
+  source_leaves: tuple
+
+
+def _make_trajectory_state_buffer(
+    source_game: Game,
+    rollout_length: int,
+) -> _TrajectoryStateBuffer:
+  states = utils.map_single_structure(
+      lambda leaf: np.empty(
+          (rollout_length + 1,) + np.asarray(leaf).shape,
+          dtype=np.asarray(leaf).dtype,
+      ),
+      source_game,
+  )
+  slots = [
+      utils.map_single_structure(lambda leaf, i=i: leaf[i], states)
+      for i in range(rollout_length + 1)
+  ]
+  return _TrajectoryStateBuffer(
+      states=states,
+      slots=slots,
+      slot_leaves=[tuple(jax.tree.leaves(slot)) for slot in slots],
+      source_leaves=tuple(jax.tree.leaves(source_game)),
+  )
+
+
+def _copy_state_slot(state_buffer: _TrajectoryStateBuffer, index: int):
+  for dst, src in zip(
+      state_buffer.slot_leaves[index],
+      state_buffer.source_leaves,
+  ):
+    dst[...] = src
+
+
+def _trajectory_slice(
+    *,
+    states: Game,
+    actions: SampleOutputs,
+    rewards: np.ndarray,
+    is_resetting: np.ndarray,
+    initial_state,
+    delayed_actions: list[SampleOutputs],
+    name_code: np.ndarray,
+    batch_slice: slice,
+) -> Trajectory:
+  batch_size = batch_slice.stop - batch_slice.start
+  return Trajectory(
+      states=utils.map_single_structure(
+          lambda x: np.asarray(x[:, batch_slice]).copy(), states),
+      name=np.broadcast_to(
+          name_code[batch_slice],
+          (is_resetting.shape[0], batch_size),
+      ).copy(),
+      actions=utils.map_single_structure(lambda x: x[:, batch_slice], actions),
+      rewards=rewards[:, batch_slice],
+      is_resetting=is_resetting[:, batch_slice].copy(),
+      initial_state=initial_state,
+      delayed_actions=[
+          utils.map_single_structure(lambda x: x[batch_slice], action)
+          for action in delayed_actions
+      ],
+  )
+
+
+def _batch_actions(actions: list[SampleOutputs]) -> SampleOutputs:
+  return jax.tree.map(lambda *xs: np.stack(xs, axis=0), *actions)
+
+
+def _sample_chunk(
+    actor: tp.Any,
+    chunk_inputs: list[tuple[Game, np.ndarray]],
+) -> SampleOutputs:
+  return actor.multi_step_stacked_device(chunk_inputs)
+
+
+def _replay_delayed_controller_queue(
+    queue: collections.deque,
+    queue_start: list,
+    sample_outputs: SampleOutputs,
+    reset_masks: list[np.ndarray],
+    neutral_controller,
+):
+  # The sim consumes controller inputs after policy delay, so while collecting a
+  # chunk we have to step with the queue as it existed at chunk start. Once the
+  # actor returns the whole time-stacked chunk, replay those sampled controllers
+  # into the delay queue in order, applying neutral reset sentinels lane-wise.
+  queue.clear()
+  queue.extend(queue_start)
+  for index, reset_mask in enumerate(reset_masks):
+    if np.any(reset_mask):
+      _reset_delayed_controller_queue(queue, neutral_controller, reset_mask)
+    controller = jax.tree.map(
+        lambda x: np.asarray(x[int(index)]).copy(),
+        sample_outputs.controller_state,
+    )
+    queue.append(controller)
+    queue.popleft()
+
+
+def _copy_to_numpy_tree(value):
+  return utils.map_single_structure(lambda x: np.asarray(x).copy(), value)
+
+
+def _reset_delayed_controller_queue(
+    queue: collections.deque,
+    neutral_controller,
+    reset_mask: np.ndarray,
+):
+  reset_mask = np.asarray(reset_mask, dtype=np.bool_)
+  for index, value in enumerate(queue):
+    queue[index] = utils.map_nt(
+        lambda controller, neutral: _reset_leaf(
+            controller, neutral, reset_mask),
+        value,
+        neutral_controller,
+    )
+
+
+def _reset_leaf(value, default, reset: np.ndarray):
+  while reset.ndim < value.ndim:
+    reset = reset[..., None]
+  return np.where(reset, default, value)

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -26,6 +26,7 @@ from slippi_ai.controller_heads import SampleOutputs
 from slippi_ai.data import NAME_DTYPE
 from slippi_ai.evaluators import Port, Timings, Trajectory
 from slippi_ai.jax import policies
+from slippi_ai.sim_env import observations
 from slippi_ai.types import Game
 
 
@@ -149,12 +150,7 @@ class JaxSimRolloutWorker:
     self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
     self._dummy_outputs = self.actor._policy.controller_head.dummy_sample_outputs(
         [self._num_players])
-    self._game_batch = self._env.game_batch_buffers
-    self._env.write_current_game(self._game_batch, self._needs_reset)
-    self._state_buffer = _make_trajectory_state_buffer(
-        self._game_batch.game, self._rollout_length)
-    self._reset_buffer = np.empty(
-        (self._rollout_length + 1, self._num_players), dtype=np.bool_)
+    self._make_trajectory_buffers()
     self._reset_delay_queues()
 
   def _reset_delay_queues(self):
@@ -188,10 +184,7 @@ class JaxSimRolloutWorker:
     self.stop()
     self._env = self._build_env()
     self._needs_reset = np.ones(self._num_envs, dtype=np.bool_)
-    self._game_batch = self._env.game_batch_buffers
-    self._env.write_current_game(self._game_batch, self._needs_reset)
-    self._state_buffer = _make_trajectory_state_buffer(
-        self._game_batch.game, self._rollout_length)
+    self._make_trajectory_buffers()
     self._reset_delay_queues()
 
   def update_variables(self, updates):
@@ -214,9 +207,9 @@ class JaxSimRolloutWorker:
       raise ValueError(
           f'JaxSimRolloutWorker was built for rollout_length={self._rollout_length}, '
           f'got rollout({num_steps}).')
-    self._env.write_current_game(self._game_batch, self._needs_reset)
-    state_buffer = self._state_buffer
-    reset_buffer = self._reset_buffer
+    trajectory_buffers = self._trajectory_buffers
+    reset_buffer = trajectory_buffers.needs_reset
+    self._env.write_current_game(trajectory_buffers.frames[0], self._needs_reset)
     trajectory_actions = []
     initial_state = self.actor.hidden_state()
     if self._opponent_actor is None:
@@ -239,13 +232,8 @@ class JaxSimRolloutWorker:
 
       for local_t in range(chunk_len):
         t = chunk_start + local_t
-        copy_start = time.perf_counter()
-        _copy_state_slot(state_buffer, t)
-        reset_buffer[t] = self._game_batch.needs_reset
-        timings['state_copy'] += time.perf_counter() - copy_start
-
         reset_mask = reset_buffer[t]
-        chunk_inputs.append((state_buffer.slots[t], reset_mask))
+        chunk_inputs.append((trajectory_buffers.frames[t].game, reset_mask))
         chunk_reset_masks.append(reset_mask)
         if np.any(reset_mask):
           _reset_delayed_controller_queue(
@@ -262,8 +250,8 @@ class JaxSimRolloutWorker:
             delayed_controller,
             axis_spacing=self._controller_spacing[0],
             shoulder_spacing=self._controller_spacing[1],
+            output_game_batch=trajectory_buffers.frames[t + 1],
         )
-        self._env.write_current_game(self._game_batch, self._needs_reset)
         timings['env_step'] += time.perf_counter() - env_start
 
       if self._opponent_actor is None:
@@ -322,14 +310,10 @@ class JaxSimRolloutWorker:
 
     # Capture the T+1 terminal observation and assemble the learner trajectory
     # trees expected by the existing PPO path.
-    copy_start = time.perf_counter()
-    _copy_state_slot(state_buffer, num_steps)
-    reset_buffer[num_steps] = self._game_batch.needs_reset
     trajectory_actions.append(self._delayed_outputs_queue[0])
-    timings['state_copy'] += time.perf_counter() - copy_start
 
     build_start = time.perf_counter()
-    time_major_states = state_buffer.states
+    time_major_states = trajectory_buffers.game
     encoded_states = self.actor._policy.network.encode_game(time_major_states)
     rewards = reward.compute_rewards(time_major_states)
     batched_actions = _batch_actions(trajectory_actions)
@@ -351,7 +335,7 @@ class JaxSimRolloutWorker:
           batch_slice=batch_slice,
       )
     timing = {
-        'env_pop': timings['state_copy'] / max(num_steps, 1),
+        'env_pop': 0.0,
         'env_push': timings['env_step'] / max(num_steps, 1),
         'agent_step': {
             port: timings[f'agent_step_{port}'] / max(num_steps, 1)
@@ -373,51 +357,12 @@ class JaxSimRolloutWorker:
       )
     return sim_env.SimBatchedEnvironment(**self._env_kwargs)
 
-
-class _TrajectoryStateBuffer(tp.NamedTuple):
-  """Time-major storage for T+1 policy observations.
-
-  `write_current_game()` reuses one mutable Game tree, while the learner needs
-  the whole rollout after the sim has advanced. `slots` are NumPy views into the
-  time-major `states` tree, so copying into a slot writes directly into the
-  corresponding frame of the final trajectory buffer.
-  """
-
-  states: Game
-  slots: list[Game]
-  slot_leaves: list[tuple]
-  source_leaves: tuple
-
-
-def _make_trajectory_state_buffer(
-    source_game: Game,
-    rollout_length: int,
-) -> _TrajectoryStateBuffer:
-  states = utils.map_single_structure(
-      lambda leaf: np.empty(
-          (rollout_length + 1,) + np.asarray(leaf).shape,
-          dtype=np.asarray(leaf).dtype,
-      ),
-      source_game,
-  )
-  slots = [
-      utils.map_single_structure(lambda leaf, i=i: leaf[i], states)
-      for i in range(rollout_length + 1)
-  ]
-  return _TrajectoryStateBuffer(
-      states=states,
-      slots=slots,
-      slot_leaves=[tuple(jax.tree.leaves(slot)) for slot in slots],
-      source_leaves=tuple(jax.tree.leaves(source_game)),
-  )
-
-
-def _copy_state_slot(state_buffer: _TrajectoryStateBuffer, index: int):
-  for dst, src in zip(
-      state_buffer.slot_leaves[index],
-      state_buffer.source_leaves,
-  ):
-    dst[...] = src
+  def _make_trajectory_buffers(self):
+    if isinstance(self._env, sim_env.MultiprocessSimEnvironment):
+      self._trajectory_buffers = self._env.trajectory_buffers
+    else:
+      self._trajectory_buffers = observations.GameBatchBuffers.time_major(
+          self._num_envs, self._rollout_length + 1)
 
 
 def _trajectory_slice(

--- a/slippi_ai/sim_env/jax_rollout.py
+++ b/slippi_ai/sim_env/jax_rollout.py
@@ -49,9 +49,9 @@ class JaxSimRolloutWorker:
       async_envs: bool = False,
       inner_batch_size: int = 1,
   ):
-    self._num_envs = int(num_envs)
+    self._num_envs = num_envs
     self._num_players = self._num_envs * len(self.ports)
-    self._rollout_length = int(rollout_length)
+    self._rollout_length = rollout_length
     self._batch_slice_by_port = {
         port: slice(i * self._num_envs, (i + 1) * self._num_envs)
         for i, port in enumerate(self.ports)
@@ -129,12 +129,12 @@ class JaxSimRolloutWorker:
       raise ValueError('sim env only supports the default controller embedding')
     controller_config = controller_config['default']
     self._controller_spacing = (
-        int(controller_config['axis_spacing']),
-        int(controller_config['shoulder_spacing']),
+        controller_config['axis_spacing'],
+        controller_config['shoulder_spacing'],
     )
-    self._batch_steps = max(1, int(batch_steps))
-    self._async_envs = bool(async_envs)
-    self._inner_batch_size = int(inner_batch_size)
+    self._batch_steps = max(1, batch_steps)
+    self._async_envs = async_envs
+    self._inner_batch_size = inner_batch_size
     self._env_kwargs = dict(
         num_envs=self._num_envs,
         players=[kwargs['players'] for kwargs in dolphin_kwargs],
@@ -208,7 +208,6 @@ class JaxSimRolloutWorker:
   ) -> tuple[tp.Mapping[Port, Trajectory], Timings]:
     del verbose
     timings: dict[str, float] = collections.defaultdict(float)
-    num_steps = int(num_steps)
     if num_steps != self._rollout_length:
       raise ValueError(
           f'JaxSimRolloutWorker was built for rollout_length={self._rollout_length}, '

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -1,0 +1,395 @@
+"""Multiprocess wrapper for sharding sim env steps across CPU workers.
+
+The main JAX process owns policy inference plus the shared observation/action
+buffers. Each worker owns a normal `SimBatchedEnvironment` shard, waits for the
+main process to publish encoded actions, steps its shard, and fills its slice of
+the shared `GameBatchBuffers`. The interface mirrors the methods used by
+`JaxSimRolloutWorker`, so rollout assembly stays the same as the single-process
+path.
+"""
+
+import dataclasses
+import math
+import multiprocessing as mp
+from multiprocessing import shared_memory
+import queue
+import traceback
+import typing as tp
+
+import melee
+import numpy as np
+
+from slippi_ai.sim_env import env as sim_env
+from slippi_ai.sim_env.observations import (
+    ArrayAllocator,
+    GameBatch,
+    GameBatchBuffers,
+)
+from slippi_ai.types import Buttons, Controller, Stick
+
+
+_BARRIER_TIMEOUT_S = 900.0
+
+
+@dataclasses.dataclass(frozen=True)
+class SharedArraySpec:
+  name: str
+  shape: tuple[int, ...]
+  dtype: np.dtype
+
+
+class SharedArrayOwner:
+  """Main process allocator, owns shared NumPy arrays and unlinks them during
+  wrapper shutdown. Every call to array() creates a shared memory block and
+  returns a NumPy view."""
+
+  def __init__(self):
+    self.specs: list[SharedArraySpec] = []
+    self._blocks: list[shared_memory.SharedMemory] = []
+
+  def array(self, shape: tuple[int, ...], dtype) -> np.ndarray:
+    dtype = np.dtype(dtype)
+    size = math.prod(shape) * dtype.itemsize
+    block = shared_memory.SharedMemory(create=True, size=size)
+    array = np.ndarray(shape, dtype=dtype, buffer=block.buf)
+    array.fill(0)
+    self.specs.append(SharedArraySpec(block.name, shape, dtype))
+    self._blocks.append(block)
+    return array
+
+  def close(self):
+    for block in self._blocks:
+      block.close()
+
+  def unlink(self):
+    for block in self._blocks:
+      try:
+        block.unlink()
+      except FileNotFoundError:
+        pass
+
+
+class SharedArrayAttacher:
+  """Worker-side mirror of SharedArrayOwner. Attaches to arrays in the same
+  order the owner allocated them."""
+
+  def __init__(self, specs: tp.Sequence[SharedArraySpec]):
+    self._specs = tuple(specs)
+    self._index = 0
+    self._blocks: list[shared_memory.SharedMemory] = []
+
+  def array(self, shape: tuple[int, ...], dtype) -> np.ndarray:
+    spec = self._specs[self._index]
+    self._index += 1
+    dtype = np.dtype(dtype)
+    if shape != spec.shape or dtype != spec.dtype:
+      raise ValueError(
+          f'shared array mismatch: expected {spec.shape}/{spec.dtype}, '
+          f'got {shape}/{dtype}')
+    block = shared_memory.SharedMemory(name=spec.name)
+    self._blocks.append(block)
+    return np.ndarray(spec.shape, dtype=dtype, buffer=block.buf)
+
+  def close(self):
+    for block in self._blocks:
+      block.close()
+
+
+class MultiprocessSimEnvironment:
+  """Process-sharded `SimBatchedEnvironment` wrapper for JAX rollout."""
+
+  def __init__(
+      self,
+      *,
+      num_envs: int,
+      inner_batch_size: int,
+      players: tp.Sequence[sim_env.PlayerConfigs],
+      stage: tp.Sequence[melee.Stage],
+      frame_buffer_length: int,
+      max_frame_id: int = -1,
+      data_dir: str | None = None,
+      fake: bool = False,
+  ):
+    self._num_envs = int(num_envs)
+    self._inner_batch_size = int(inner_batch_size)
+    if self._num_envs % self._inner_batch_size:
+      raise ValueError(
+          f'num_envs={self._num_envs} must be divisible by '
+          f'inner_batch_size={self._inner_batch_size}.')
+    self._num_workers = self._num_envs // self._inner_batch_size
+    self._closed = False
+    self._stage_by_env = np.asarray(stage, dtype=object)
+
+    self._obs_owner = SharedArrayOwner()
+    self._action_owner = SharedArrayOwner()
+    self._misc_owner = SharedArrayOwner()
+    self._game_batch = GameBatchBuffers.with_allocator(
+        self._num_envs, self._obs_owner.array)
+    self._shared_action = shared_action_buffer(
+        self._num_envs * 2, self._action_owner.array)
+    self._needs_reset = self._misc_owner.array((self._num_envs,), np.bool_)
+    self._episode_ids = self._misc_owner.array((self._num_envs,), np.int64)
+    self._controller_spacing = self._misc_owner.array((2,), np.int32)
+
+    self._context = mp.get_context('spawn')
+    self._actions_ready = self._context.Barrier(self._num_workers + 1)
+    self._observations_ready = self._context.Barrier(self._num_workers + 1)
+    self._stop_event = self._context.Event()
+    self._completed_queue = self._context.Queue()
+    self._error_queue = self._context.Queue()
+    self._processes = []
+
+    for worker_id in range(self._num_workers):
+      start = worker_id * self._inner_batch_size
+      stop = start + self._inner_batch_size
+      process = self._context.Process(
+          target=_worker_main,
+          name=f'sim-env-worker-{worker_id}',
+          kwargs=dict(
+              worker_id=worker_id,
+              offset=start,
+              batch_size=self._inner_batch_size,
+              total_envs=self._num_envs,
+              players=players[start:stop],
+              stages=stage[start:stop],
+              frame_buffer_length=frame_buffer_length,
+              max_frame_id=max_frame_id,
+              data_dir=data_dir,
+              fake=fake,
+              obs_specs=self._obs_owner.specs,
+              action_specs=self._action_owner.specs,
+              misc_specs=self._misc_owner.specs,
+              actions_ready=self._actions_ready,
+              observations_ready=self._observations_ready,
+              stop_event=self._stop_event,
+              completed_queue=self._completed_queue,
+              error_queue=self._error_queue,
+          ),
+      )
+      process.start()
+      self._processes.append(process)
+
+    self._wait_for_observations('initial observations')
+
+  def stop(self):
+    if self._closed:
+      return
+    self._closed = True
+    self._stop_event.set()
+    try:
+      self._actions_ready.wait(timeout=1.0)
+    except Exception:
+      pass
+    for process in self._processes:
+      process.join(timeout=5.0)
+      if process.is_alive():
+        process.terminate()
+        process.join(timeout=5.0)
+      process.close()
+    self._obs_owner.close()
+    self._action_owner.close()
+    self._misc_owner.close()
+    self._obs_owner.unlink()
+    self._action_owner.unlink()
+    self._misc_owner.unlink()
+
+  def current_game_batch(self, needs_reset: np.ndarray | None = None) -> GameBatch:
+    del needs_reset
+    return GameBatch(
+        game=self._game_batch.game,
+        needs_reset=self._game_batch.needs_reset,
+    )
+
+  def step_encoded(
+      self,
+      controller_state: Controller,
+      *,
+      axis_spacing: int,
+      shoulder_spacing: int,
+  ) -> np.ndarray:
+    self._controller_spacing[:] = (axis_spacing, shoulder_spacing)
+    copy_action_to_shared_buffer(self._shared_action, controller_state)
+    self._wait_for_actions()
+    self._wait_for_observations('step observations')
+    return self._needs_reset
+
+  def active_games(self) -> list[dict[str, int | str]]:
+    return [
+        {
+            'env_id': env_id,
+            'episode_id': int(self._episode_ids[env_id]),
+            'stage': self._stage_by_env[env_id].name,
+            'stage_id': int(self._stage_by_env[env_id].value),
+        }
+        for env_id in range(self._num_envs)
+    ]
+
+  def pop_completed_games(self) -> list[dict[str, tp.Any]]:
+    games = []
+    while True:
+      try:
+        games.extend(self._completed_queue.get_nowait())
+      except queue.Empty:
+        return games
+
+  def _wait_for_actions(self):
+    self._check_worker_errors()
+    try:
+      _barrier_wait(self._actions_ready, 'action release')
+    except RuntimeError:
+      self._check_worker_errors()
+      raise
+
+  def _wait_for_observations(self, label: str):
+    self._check_worker_errors()
+    try:
+      _barrier_wait(self._observations_ready, label)
+    except RuntimeError:
+      self._check_worker_errors()
+      raise
+    self._check_worker_errors()
+
+  def _check_worker_errors(self):
+    try:
+      error = self._error_queue.get_nowait()
+    except queue.Empty:
+      return
+    raise RuntimeError(error)
+
+
+def _worker_main(
+    *,
+    worker_id: int,
+    offset: int,
+    batch_size: int,
+    total_envs: int,
+    players: tp.Sequence[sim_env.PlayerConfigs],
+    stages: tp.Sequence[melee.Stage],
+    frame_buffer_length: int,
+    max_frame_id: int,
+    data_dir: str | None,
+    fake: bool,
+    obs_specs: tp.Sequence[SharedArraySpec],
+    action_specs: tp.Sequence[SharedArraySpec],
+    misc_specs: tp.Sequence[SharedArraySpec],
+    actions_ready,
+    observations_ready,
+    stop_event,
+    completed_queue,
+    error_queue,
+):
+  obs_attacher = SharedArrayAttacher(obs_specs)
+  action_attacher = SharedArrayAttacher(action_specs)
+  misc_attacher = SharedArrayAttacher(misc_specs)
+  env = None
+  try:
+    game_batch = GameBatchBuffers.with_allocator(total_envs, obs_attacher.array)
+    shared_action = shared_action_buffer(total_envs * 2, action_attacher.array)
+    needs_reset = misc_attacher.array((total_envs,), np.bool_)
+    episode_ids = misc_attacher.array((total_envs,), np.int64)
+    controller_spacing = misc_attacher.array((2,), np.int32)
+    env = sim_env.SimBatchedEnvironment(
+        num_envs=batch_size,
+        players=players,
+        stage=stages,
+        frame_buffer_length=frame_buffer_length,
+        max_frame_id=max_frame_id,
+        data_dir=data_dir,
+        fake=fake,
+    )
+    env_slice = slice(offset, offset + batch_size)
+    p1_slice = env_slice
+    p2_slice = slice(total_envs + offset, total_envs + offset + batch_size)
+
+    local_reset = np.ones(batch_size, dtype=np.bool_)
+    needs_reset[env_slice] = local_reset
+    episode_ids[env_slice] = 0
+    game_batch.fill_slice(
+        env.buffers.gamestate_view[env.cursor],
+        local_reset,
+        env_slice,
+        env._last_controllers,
+        controller_slice=slice(None),
+    )
+    _barrier_wait(observations_ready, f'worker {worker_id} initial observations')
+
+    while not stop_event.is_set():
+      _barrier_wait(actions_ready, f'worker {worker_id} action wait')
+      if stop_event.is_set():
+        break
+      local_reset = env.step_encoded_slices(
+          shared_action,
+          player_slices=(p1_slice, p2_slice),
+          axis_spacing=controller_spacing[0],
+          shoulder_spacing=controller_spacing[1],
+      )
+      needs_reset[env_slice] = local_reset
+      episode_ids[env_slice] = env._episode_ids
+      game_batch.fill_slice(
+          env.buffers.gamestate_view[env.cursor],
+          local_reset,
+          env_slice,
+          env._last_controllers,
+          controller_slice=slice(None),
+      )
+      completed_games = env.pop_completed_games()
+      if completed_games:
+        for game in completed_games:
+          game['env_id'] += offset
+        completed_queue.put(completed_games)
+      _barrier_wait(observations_ready, f'worker {worker_id} observations')
+  except BaseException:
+    error_queue.put(traceback.format_exc())
+    _abort_barrier(actions_ready)
+    _abort_barrier(observations_ready)
+  finally:
+    if env is not None:
+      env.stop()
+    obs_attacher.close()
+    action_attacher.close()
+    misc_attacher.close()
+
+
+def shared_action_buffer(
+    total_players: int,
+    allocate_array: ArrayAllocator,
+) -> Controller:
+  shape = (total_players,)
+  return Controller(
+      main_stick=Stick(
+          x=allocate_array(shape, np.uint8),
+          y=allocate_array(shape, np.uint8),
+      ),
+      c_stick=Stick(
+          x=allocate_array(shape, np.uint8),
+          y=allocate_array(shape, np.uint8),
+      ),
+      shoulder=allocate_array(shape, np.uint8),
+      buttons=Buttons(**{
+          name: allocate_array(shape, np.bool_)
+          for name in Buttons._fields
+      }),
+  )
+
+
+def copy_action_to_shared_buffer(dst: Controller, src: Controller):
+  np.copyto(dst.main_stick.x, np.asarray(src.main_stick.x), casting='unsafe')
+  np.copyto(dst.main_stick.y, np.asarray(src.main_stick.y), casting='unsafe')
+  np.copyto(dst.c_stick.x, np.asarray(src.c_stick.x), casting='unsafe')
+  np.copyto(dst.c_stick.y, np.asarray(src.c_stick.y), casting='unsafe')
+  np.copyto(dst.shoulder, np.asarray(src.shoulder), casting='unsafe')
+  for name in Buttons._fields:
+    np.copyto(getattr(dst.buttons, name), np.asarray(getattr(src.buttons, name)))
+
+def _barrier_wait(barrier, label: str):
+  try:
+    barrier.wait(timeout=_BARRIER_TIMEOUT_S)
+  except Exception as exc:
+    raise RuntimeError(f'timed out or broke barrier during {label}') from exc
+
+
+def _abort_barrier(barrier):
+  try:
+    barrier.abort()
+  except Exception:
+    pass

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -3,9 +3,7 @@
 The main JAX process owns policy inference plus the shared observation/action
 buffers. Each worker owns a normal `SimBatchedEnvironment` shard, waits for the
 main process to publish encoded actions, steps its shard, and fills its slice of
-the shared `GameBatchBuffers`. The interface mirrors the methods used by
-`JaxSimRolloutWorker`, so rollout assembly stays the same as the single-process
-path.
+the shared `GameBatchBuffers`.
 """
 
 import dataclasses

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -133,6 +133,9 @@ class MultiprocessSimEnvironment:
     self._needs_reset = self._misc_owner.array((self._num_envs,), np.bool_)
     self._episode_ids = self._misc_owner.array((self._num_envs,), np.int64)
     self._controller_spacing = self._misc_owner.array((2,), np.int32)
+    # Parent sets the target trajectory frame before releasing workers. Workers
+    # fill their shard of that frame, then parent marks it current after the
+    # observation barrier completes.
     self._write_index = self._misc_owner.array((1,), np.int32)
     self._current_index = 0
 
@@ -216,6 +219,9 @@ class MultiprocessSimEnvironment:
       game_batch: GameBatchBuffers,
       needs_reset: np.ndarray | None = None,
   ):
+    # Workers have already written the latest observation into shared memory.
+    # This only moves that current frame to another trajectory slot, usually
+    # frame 0 when a new rollout starts.
     del needs_reset
     index = self._slot_by_id[id(game_batch)]
     if index == self._current_index:

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -321,11 +321,10 @@ def _worker_main(
     local_reset = np.ones(batch_size, dtype=np.bool_)
     needs_reset[env_slice] = local_reset
     episode_ids[env_slice] = 0
-    game_batch.fill_slice(
-        env.buffers.gamestate_view[env.cursor],
+    env.write_current_game(
+        game_batch,
         local_reset,
-        env_slice,
-        env._last_controllers,
+        env_slice=env_slice,
         controller_slice=slice(None),
     )
     _barrier_wait(observations_ready, f'worker {worker_id} initial observations')
@@ -344,12 +343,11 @@ def _worker_main(
           shoulder_spacing=controller_spacing[1],
       )
       needs_reset[env_slice] = local_reset
-      episode_ids[env_slice] = env._episode_ids
-      game_batch.fill_slice(
-          env.buffers.gamestate_view[env.cursor],
+      episode_ids[env_slice] = env.episode_ids
+      env.write_current_game(
+          game_batch,
           local_reset,
-          env_slice,
-          env._last_controllers,
+          env_slice=env_slice,
           controller_slice=slice(None),
       )
       completed_games = env.pop_completed_games()

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -120,6 +120,9 @@ class MultiprocessSimEnvironment:
     self._closed = False
     self._stage_by_env = np.asarray(stage, dtype=object)
 
+    # Shared buffers are allocated once by the parent. Workers attach to the
+    # same blocks and fill only their shard, so rollout can read one global
+    # GameBatch without gathering per-worker Python objects every frame.
     self._obs_owner = SharedArrayOwner()
     self._action_owner = SharedArrayOwner()
     self._misc_owner = SharedArrayOwner()
@@ -131,6 +134,8 @@ class MultiprocessSimEnvironment:
     self._episode_ids = self._misc_owner.array((self._num_envs,), np.int64)
     self._controller_spacing = self._misc_owner.array((2,), np.int32)
 
+    # Two barriers define one synchronous sim frame: parent publishes actions,
+    # workers step their shards, then parent reads the completed observations.
     self._context = mp.get_context('spawn')
     self._actions_ready = self._context.Barrier(self._num_workers + 1)
     self._observations_ready = self._context.Barrier(self._num_workers + 1)
@@ -139,6 +144,8 @@ class MultiprocessSimEnvironment:
     self._error_queue = self._context.Queue()
     self._processes = []
 
+    # Each worker gets a contiguous env range. The policy-facing action buffer
+    # remains global: [all port-1 perspectives, all port-2 perspectives].
     for worker_id in range(self._num_workers):
       start = worker_id * self._inner_batch_size
       stop = start + self._inner_batch_size
@@ -169,6 +176,7 @@ class MultiprocessSimEnvironment:
       process.start()
       self._processes.append(process)
 
+    # Workers publish their initial observations before the first policy call.
     self._wait_for_observations('initial observations')
 
   def stop(self):
@@ -207,6 +215,8 @@ class MultiprocessSimEnvironment:
       axis_spacing: int,
       shoulder_spacing: int,
   ) -> np.ndarray:
+    # Copy JAX outputs into shared host buffers, release all workers for one sim
+    # frame, then wait until every shard has filled its observation slice.
     self._controller_spacing[:] = (axis_spacing, shoulder_spacing)
     copy_action_to_shared_buffer(self._shared_action, controller_state)
     self._wait_for_actions()
@@ -278,6 +288,8 @@ def _worker_main(
     completed_queue,
     error_queue,
 ):
+  # Recreate NumPy views over the parent's shared-memory blocks in the exact
+  # allocation order used during parent setup.
   obs_attacher = SharedArrayAttacher(obs_specs)
   action_attacher = SharedArrayAttacher(action_specs)
   misc_attacher = SharedArrayAttacher(misc_specs)
@@ -301,6 +313,8 @@ def _worker_main(
     p1_slice = env_slice
     p2_slice = slice(total_envs + offset, total_envs + offset + batch_size)
 
+    # Seed the parent-visible GameBatch with the shard's starting state so the
+    # first policy inference sees valid observations.
     local_reset = np.ones(batch_size, dtype=np.bool_)
     needs_reset[env_slice] = local_reset
     episode_ids[env_slice] = 0
@@ -314,6 +328,9 @@ def _worker_main(
     _barrier_wait(observations_ready, f'worker {worker_id} initial observations')
 
     while not stop_event.is_set():
+      # The parent has already copied actions into shared_action. This worker
+      # consumes only its port-1 and port-2 slices, steps its local EnvBatch, and
+      # writes results back into the same global GameBatch buffers.
       _barrier_wait(actions_ready, f'worker {worker_id} action wait')
       if stop_event.is_set():
         break
@@ -354,6 +371,8 @@ def shared_action_buffer(
     total_players: int,
     allocate_array: ArrayAllocator,
 ) -> Controller:
+  # Encoded controller buckets are compact uint8/bool values produced by the
+  # JAX controller head, not libmelee float stick coordinates.
   shape = (total_players,)
   return Controller(
       main_stick=Stick(

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -20,7 +20,6 @@ import numpy as np
 from slippi_ai.sim_env import env as sim_env
 from slippi_ai.sim_env.observations import (
     ArrayAllocator,
-    GameBatch,
     GameBatchBuffers,
 )
 from slippi_ai.types import Buttons, Controller, Stick
@@ -199,12 +198,18 @@ class MultiprocessSimEnvironment:
     self._action_owner.unlink()
     self._misc_owner.unlink()
 
-  def current_game_batch(self, needs_reset: np.ndarray | None = None) -> GameBatch:
+  @property
+  def game_batch_buffers(self) -> GameBatchBuffers:
+    return self._game_batch
+
+  def write_current_game(
+      self,
+      game_batch: GameBatchBuffers,
+      needs_reset: np.ndarray | None = None,
+  ):
     del needs_reset
-    return GameBatch(
-        game=self._game_batch.game,
-        needs_reset=self._game_batch.needs_reset,
-    )
+    if game_batch is not self._game_batch:
+      raise ValueError('multiprocess sim writes into its shared game batch')
 
   def step_encoded(
       self,

--- a/slippi_ai/sim_env/multiprocess_env.py
+++ b/slippi_ai/sim_env/multiprocess_env.py
@@ -123,13 +123,18 @@ class MultiprocessSimEnvironment:
     self._obs_owner = SharedArrayOwner()
     self._action_owner = SharedArrayOwner()
     self._misc_owner = SharedArrayOwner()
-    self._game_batch = GameBatchBuffers.with_allocator(
-        self._num_envs, self._obs_owner.array)
+    self._trajectory_buffers = GameBatchBuffers.time_major(
+        self._num_envs, frame_buffer_length, self._obs_owner.array)
+    self._slot_by_id = {
+        id(frame): i for i, frame in enumerate(self._trajectory_buffers.frames)
+    }
     self._shared_action = shared_action_buffer(
         self._num_envs * 2, self._action_owner.array)
     self._needs_reset = self._misc_owner.array((self._num_envs,), np.bool_)
     self._episode_ids = self._misc_owner.array((self._num_envs,), np.int64)
     self._controller_spacing = self._misc_owner.array((2,), np.int32)
+    self._write_index = self._misc_owner.array((1,), np.int32)
+    self._current_index = 0
 
     # Two barriers define one synchronous sim frame: parent publishes actions,
     # workers step their shards, then parent reads the completed observations.
@@ -200,7 +205,11 @@ class MultiprocessSimEnvironment:
 
   @property
   def game_batch_buffers(self) -> GameBatchBuffers:
-    return self._game_batch
+    return self._trajectory_buffers.frames[self._current_index]
+
+  @property
+  def trajectory_buffers(self) -> GameBatchBuffers:
+    return self._trajectory_buffers
 
   def write_current_game(
       self,
@@ -208,8 +217,11 @@ class MultiprocessSimEnvironment:
       needs_reset: np.ndarray | None = None,
   ):
     del needs_reset
-    if game_batch is not self._game_batch:
-      raise ValueError('multiprocess sim writes into its shared game batch')
+    index = self._slot_by_id[id(game_batch)]
+    if index == self._current_index:
+      return
+    self._trajectory_buffers.copy_frame(index, self._current_index)
+    self._current_index = index
 
   def step_encoded(
       self,
@@ -217,13 +229,20 @@ class MultiprocessSimEnvironment:
       *,
       axis_spacing: int,
       shoulder_spacing: int,
+      output_game_batch: GameBatchBuffers | None = None,
   ) -> np.ndarray:
     # Copy JAX outputs into shared host buffers, release all workers for one sim
     # frame, then wait until every shard has filled its observation slice.
     self._controller_spacing[:] = (axis_spacing, shoulder_spacing)
+    if output_game_batch is None:
+      output_index = self._current_index
+    else:
+      output_index = self._slot_by_id[id(output_game_batch)]
+    self._write_index[0] = output_index
     copy_action_to_shared_buffer(self._shared_action, controller_state)
     self._wait_for_actions()
     self._wait_for_observations('step observations')
+    self._current_index = output_index
     return self._needs_reset
 
   def active_games(self) -> list[dict[str, int | str]]:
@@ -298,11 +317,17 @@ def _worker_main(
   misc_attacher = SharedArrayAttacher(misc_specs)
   env = None
   try:
-    game_batch = GameBatchBuffers.with_allocator(total_envs, obs_attacher.array)
+    game_batches = GameBatchBuffers.time_major(
+        total_envs,
+        frame_buffer_length,
+        obs_attacher.array,
+        fill_batch_size=batch_size,
+    )
     shared_action = shared_action_buffer(total_envs * 2, action_attacher.array)
     needs_reset = misc_attacher.array((total_envs,), np.bool_)
     episode_ids = misc_attacher.array((total_envs,), np.int64)
     controller_spacing = misc_attacher.array((2,), np.int32)
+    write_index = misc_attacher.array((1,), np.int32)
     env = sim_env.SimBatchedEnvironment(
         num_envs=batch_size,
         players=players,
@@ -322,7 +347,7 @@ def _worker_main(
     needs_reset[env_slice] = local_reset
     episode_ids[env_slice] = 0
     env.write_current_game(
-        game_batch,
+        game_batches.frames[0],
         local_reset,
         env_slice=env_slice,
         controller_slice=slice(None),
@@ -345,7 +370,7 @@ def _worker_main(
       needs_reset[env_slice] = local_reset
       episode_ids[env_slice] = env.episode_ids
       env.write_current_game(
-          game_batch,
+          game_batches.frames[int(write_index[0])],
           local_reset,
           env_slice=env_slice,
           controller_slice=slice(None),

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -130,23 +130,31 @@ def _slots_by_source(slots: SlotsView) -> dict[int, PlayerSlotView]:
   return result
 
 
-def _empty_nana(batch_size: int) -> Nana:
-  zeros_bool = np.zeros(batch_size, dtype=np.bool_)
-  zeros_f32 = np.zeros(batch_size, dtype=np.float32)
-  zeros_u16 = np.zeros(batch_size, dtype=np.uint16)
-  zeros_u8 = np.zeros(batch_size, dtype=np.uint8)
+def _empty_nana(
+    batch_size: int,
+    allocate_array: ArrayAllocator | None = None,
+) -> Nana:
+  if allocate_array is None:
+    allocate_array = lambda shape, dtype: np.zeros(shape, dtype=dtype)
+  shape = (batch_size,)
+
+  def zeros(dtype):
+    array = allocate_array(shape, dtype)
+    array[...] = 0
+    return array
+
   return Nana(
-      exists=zeros_bool.copy(),
-      percent=zeros_u16.copy(),
-      facing=zeros_bool.copy(),
-      x=zeros_f32.copy(),
-      y=zeros_f32.copy(),
-      action=zeros_u16.copy(),
-      invulnerable=zeros_bool.copy(),
-      character=zeros_u8.copy(),
-      jumps_left=zeros_u8.copy(),
-      shield_strength=zeros_f32.copy(),
-      on_ground=zeros_bool.copy(),
+      exists=zeros(np.bool_),
+      percent=zeros(np.uint16),
+      facing=zeros(np.bool_),
+      x=zeros(np.float32),
+      y=zeros(np.float32),
+      action=zeros(np.uint16),
+      invulnerable=zeros(np.bool_),
+      character=zeros(np.uint8),
+      jumps_left=zeros(np.uint8),
+      shield_strength=zeros(np.float32),
+      on_ground=zeros(np.bool_),
   )
 
 
@@ -183,13 +191,16 @@ class GameBatchBuffers:
       batch_size: int,
       *,
       _allocate_array: ArrayAllocator | None = None,
+      _percent_tmp: np.ndarray | None = None,
   ):
     if _allocate_array is None:
       _allocate_array = lambda shape, dtype: np.zeros(shape, dtype=dtype)
     self.batch_size = int(batch_size)
     self.num_players = self.batch_size * 2
     self.needs_reset = _allocate_array((self.num_players,), np.bool_)
-    self._percent_tmp = np.zeros(self.batch_size, dtype=np.float32)
+    if _percent_tmp is None:
+      _percent_tmp = np.zeros(self.batch_size, dtype=np.float32)
+    self._percent_tmp = _percent_tmp
     self._p0_arrays = _player_arrays(self.num_players, _allocate_array)
     self._p1_arrays = _player_arrays(self.num_players, _allocate_array)
     self._item_arrays = [
@@ -212,12 +223,12 @@ class GameBatchBuffers:
         p0=Player(
             **self._p0_arrays,
             controller=self._p0_controller,
-            nana=_empty_nana(self.num_players),
+            nana=_empty_nana(self.num_players, _allocate_array),
         ),
         p1=Player(
             **self._p1_arrays,
             controller=self._p1_controller,
-            nana=_empty_nana(self.num_players),
+            nana=_empty_nana(self.num_players, _allocate_array),
         ),
         stage=_allocate_array((self.num_players,), np.uint8),
         randall=Randall(
@@ -232,8 +243,46 @@ class GameBatchBuffers:
     )
 
   @staticmethod
-  def with_allocator(batch_size: int, allocate_array: ArrayAllocator):
-    return GameBatchBuffers(batch_size, _allocate_array=allocate_array)
+  def time_major(
+      batch_size: int,
+      length: int,
+      allocate_array: ArrayAllocator | None = None,
+      fill_batch_size: int | None = None,
+  ) -> 'GameBatchBuffers':
+    arrays = []
+    if allocate_array is None:
+      allocate_array = lambda shape, dtype: np.empty(shape, dtype=dtype)
+
+    def time_major_array(shape, dtype):
+      array = allocate_array((length,) + tuple(shape), dtype)
+      arrays.append(array)
+      return array
+
+    # Frame views may fill only a shard of the full batch, as in MP workers.
+    scratch = np.zeros(
+        batch_size if fill_batch_size is None else fill_batch_size,
+        dtype=np.float32)
+    storage = GameBatchBuffers(
+        batch_size, _allocate_array=time_major_array, _percent_tmp=scratch)
+    storage.frames = []
+    storage._frame_leaves = []
+    for i in range(length):
+      slot_arrays = iter(arrays)
+      storage.frames.append(GameBatchBuffers(
+          batch_size,
+          _percent_tmp=storage._percent_tmp,
+          _allocate_array=(
+              lambda shape, dtype, slot_arrays=slot_arrays: next(slot_arrays)[i]),
+      ))
+      storage._frame_leaves.append(tuple(array[i] for array in arrays))
+    return storage
+
+  def copy_frame(self, dst_index: int, src_index: int):
+    for dst, src in zip(
+        self._frame_leaves[dst_index],
+        self._frame_leaves[src_index],
+    ):
+      dst[...] = src
 
   def fill(
       self,
@@ -258,9 +307,6 @@ class GameBatchBuffers:
     start = env_slice.start or 0
     stop = env_slice.stop
     second = slice(self.batch_size + start, self.batch_size + stop)
-    local_batch = stop - start
-    if self._percent_tmp.shape[0] != local_batch:
-      self._percent_tmp = np.zeros(local_batch, dtype=np.float32)
     self.needs_reset[first] = needs_reset
     self.needs_reset[second] = needs_reset
 
@@ -286,8 +332,9 @@ class GameBatchBuffers:
     self._fill_items(frame['items'], second)
 
   def _fill_player(self, dst: PlayerArrays, target: slice, slot: PlayerSlotView):
-    np.clip(slot['percent'], 0, np.iinfo(np.uint16).max, out=self._percent_tmp)
-    dst['percent'][target] = self._percent_tmp
+    percent_tmp = self._percent_tmp[:slot.shape[0]]
+    np.clip(slot['percent'], 0, np.iinfo(np.uint16).max, out=percent_tmp)
+    dst['percent'][target] = percent_tmp
     dst['facing'][target] = slot['facing']
     dst['x'][target] = slot['pos_x']
     dst['y'][target] = slot['pos_y']

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -208,10 +208,17 @@ class GameBatchBuffers:
     })
     self._p0_controller = _controller_buffers(self.num_players, _allocate_array)
     self._p1_controller = _controller_buffers(self.num_players, _allocate_array)
-    empty_nana = _empty_nana(self.num_players)
     self.game = Game(
-        p0=Player(**self._p0_arrays, controller=self._p0_controller, nana=empty_nana),
-        p1=Player(**self._p1_arrays, controller=self._p1_controller, nana=empty_nana),
+        p0=Player(
+            **self._p0_arrays,
+            controller=self._p0_controller,
+            nana=_empty_nana(self.num_players),
+        ),
+        p1=Player(
+            **self._p1_arrays,
+            controller=self._p1_controller,
+            nana=_empty_nana(self.num_players),
+        ),
         stage=_allocate_array((self.num_players,), np.uint8),
         randall=Randall(
             x=_allocate_array((self.num_players,), np.float32),

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -249,6 +249,13 @@ class GameBatchBuffers:
       allocate_array: ArrayAllocator | None = None,
       fill_batch_size: int | None = None,
   ) -> 'GameBatchBuffers':
+    """Allocate one [time, batch] Game tree plus per-frame writable views.
+
+    Rollout needs a full T+1 observation tree for the learner, while env code
+    wants to fill one current GameBatchBuffers at a time. The returned storage
+    owns the time-major arrays in `game`; `frames[t]` is a normal
+    GameBatchBuffers view into timestep t of those same arrays.
+    """
     arrays = []
     if allocate_array is None:
       allocate_array = lambda shape, dtype: np.empty(shape, dtype=dtype)

--- a/slippi_ai/sim_env/observations.py
+++ b/slippi_ai/sim_env/observations.py
@@ -35,6 +35,7 @@ SlotsView = np.ndarray
 PlayerSlotView = np.ndarray
 ItemsView = np.ndarray
 PlayerArrays = dict[str, np.ndarray]
+ArrayAllocator = tp.Callable[[tuple[int, ...], tp.Any], np.ndarray]
 
 
 class GameBatch(tp.NamedTuple):
@@ -177,20 +178,27 @@ class GameBatchBuffers:
   in place instead of allocating a fresh Game nest for every frame.
   """
 
-  def __init__(self, batch_size: int):
+  def __init__(
+      self,
+      batch_size: int,
+      *,
+      _allocate_array: ArrayAllocator | None = None,
+  ):
+    if _allocate_array is None:
+      _allocate_array = lambda shape, dtype: np.zeros(shape, dtype=dtype)
     self.batch_size = int(batch_size)
     self.num_players = self.batch_size * 2
-    self.needs_reset = np.zeros(self.num_players, dtype=np.bool_)
+    self.needs_reset = _allocate_array((self.num_players,), np.bool_)
     self._percent_tmp = np.zeros(self.batch_size, dtype=np.float32)
-    self._p0_arrays = _player_arrays(self.num_players)
-    self._p1_arrays = _player_arrays(self.num_players)
+    self._p0_arrays = _player_arrays(self.num_players, _allocate_array)
+    self._p1_arrays = _player_arrays(self.num_players, _allocate_array)
     self._item_arrays = [
         {
-            'exists': np.zeros(self.num_players, dtype=np.bool_),
-            'type': np.zeros(self.num_players, dtype=np.uint16),
-            'state': np.zeros(self.num_players, dtype=np.uint8),
-            'x': np.zeros(self.num_players, dtype=np.float32),
-            'y': np.zeros(self.num_players, dtype=np.float32),
+            'exists': _allocate_array((self.num_players,), np.bool_),
+            'type': _allocate_array((self.num_players,), np.uint16),
+            'state': _allocate_array((self.num_players,), np.uint8),
+            'x': _allocate_array((self.num_players,), np.float32),
+            'y': _allocate_array((self.num_players,), np.float32),
         }
         for _ in Items._fields
     ]
@@ -198,23 +206,27 @@ class GameBatchBuffers:
         f'item_{i}': Item(**arrays)
         for i, arrays in enumerate(self._item_arrays)
     })
-    self._p0_controller = _controller_buffers(self.num_players)
-    self._p1_controller = _controller_buffers(self.num_players)
+    self._p0_controller = _controller_buffers(self.num_players, _allocate_array)
+    self._p1_controller = _controller_buffers(self.num_players, _allocate_array)
     empty_nana = _empty_nana(self.num_players)
     self.game = Game(
         p0=Player(**self._p0_arrays, controller=self._p0_controller, nana=empty_nana),
         p1=Player(**self._p1_arrays, controller=self._p1_controller, nana=empty_nana),
-        stage=np.zeros(self.num_players, dtype=np.uint8),
+        stage=_allocate_array((self.num_players,), np.uint8),
         randall=Randall(
-            x=np.zeros(self.num_players, dtype=np.float32),
-            y=np.zeros(self.num_players, dtype=np.float32),
+            x=_allocate_array((self.num_players,), np.float32),
+            y=_allocate_array((self.num_players,), np.float32),
         ),
         fod_platforms=FoDPlatforms(
-            left=np.zeros(self.num_players, dtype=np.float32),
-            right=np.zeros(self.num_players, dtype=np.float32),
+            left=_allocate_array((self.num_players,), np.float32),
+            right=_allocate_array((self.num_players,), np.float32),
         ),
         items=self._items,
     )
+
+  @staticmethod
+  def with_allocator(batch_size: int, allocate_array: ArrayAllocator):
+    return GameBatchBuffers(batch_size, _allocate_array=allocate_array)
 
   def fill(
       self,
@@ -236,11 +248,10 @@ class GameBatchBuffers:
     # first half and port 2 perspective in the second. p0 is the controlled
     # player and p1 is the opponent in both halves.
     first = env_slice
-    second = slice(
-        self.batch_size + int(env_slice.start or 0),
-        self.batch_size + int(env_slice.stop),
-    )
-    local_batch = int(env_slice.stop) - int(env_slice.start or 0)
+    start = env_slice.start or 0
+    stop = env_slice.stop
+    second = slice(self.batch_size + start, self.batch_size + stop)
+    local_batch = stop - start
     if self._percent_tmp.shape[0] != local_batch:
       self._percent_tmp = np.zeros(local_batch, dtype=np.float32)
     self.needs_reset[first] = needs_reset
@@ -301,35 +312,35 @@ class GameBatchBuffers:
       arrays['y'][target] = src['pos_y']
 
 
-def _player_arrays(batch_size: int) -> PlayerArrays:
+def _player_arrays(batch_size: int, allocate_array: ArrayAllocator) -> PlayerArrays:
   arrays = {
-      'percent': np.zeros(batch_size, dtype=np.uint16),
-      'facing': np.zeros(batch_size, dtype=np.bool_),
-      'x': np.zeros(batch_size, dtype=np.float32),
-      'y': np.zeros(batch_size, dtype=np.float32),
-      'action': np.zeros(batch_size, dtype=np.uint16),
-      'invulnerable': np.zeros(batch_size, dtype=np.bool_),
-      'character': np.zeros(batch_size, dtype=np.uint8),
-      'jumps_left': np.zeros(batch_size, dtype=np.uint8),
-      'shield_strength': np.zeros(batch_size, dtype=np.float32),
-      'on_ground': np.zeros(batch_size, dtype=np.bool_),
+      'percent': allocate_array((batch_size,), np.uint16),
+      'facing': allocate_array((batch_size,), np.bool_),
+      'x': allocate_array((batch_size,), np.float32),
+      'y': allocate_array((batch_size,), np.float32),
+      'action': allocate_array((batch_size,), np.uint16),
+      'invulnerable': allocate_array((batch_size,), np.bool_),
+      'character': allocate_array((batch_size,), np.uint8),
+      'jumps_left': allocate_array((batch_size,), np.uint8),
+      'shield_strength': allocate_array((batch_size,), np.float32),
+      'on_ground': allocate_array((batch_size,), np.bool_),
   }
   return arrays
 
 
-def _controller_buffers(batch_size: int) -> Controller:
+def _controller_buffers(batch_size: int, allocate_array: ArrayAllocator) -> Controller:
   controller = Controller(
       main_stick=Stick(
-          x=np.zeros(batch_size, dtype=np.float32),
-          y=np.zeros(batch_size, dtype=np.float32),
+          x=allocate_array((batch_size,), np.float32),
+          y=allocate_array((batch_size,), np.float32),
       ),
       c_stick=Stick(
-          x=np.zeros(batch_size, dtype=np.float32),
-          y=np.zeros(batch_size, dtype=np.float32),
+          x=allocate_array((batch_size,), np.float32),
+          y=allocate_array((batch_size,), np.float32),
       ),
-      shoulder=np.zeros(batch_size, dtype=np.float32),
+      shoulder=allocate_array((batch_size,), np.float32),
       buttons=Buttons(**{
-          name: np.zeros(batch_size, dtype=np.bool_)
+          name: allocate_array((batch_size,), np.bool_)
           for name in Buttons._fields
       }),
   )

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -111,8 +111,7 @@ class SimEnvTest(unittest.TestCase):
       env.step(controllers)
 
       env.reset([1])
-      state = env.current_game_batch(
-          needs_reset=np.array([False, True], dtype=np.bool_))
+      state = _game_batch(env, np.array([False, True], dtype=np.bool_))
 
       self.assertTrue(np.allclose(state.game.p0.controller.main_stick.x, [
           0.0,
@@ -159,8 +158,7 @@ class SimEnvTest(unittest.TestCase):
         character_pool='fox,falco',
     )
     try:
-      state = env.current_game_batch(
-          needs_reset=np.ones(4, dtype=np.bool_))
+      state = _game_batch(env, np.ones(4, dtype=np.bool_))
       self.assertEqual(
           state.game.p0.character[:4].tolist(),
           [
@@ -198,7 +196,7 @@ class SimEnvTest(unittest.TestCase):
         ],
     )
     try:
-      state = env.current_game_batch(np.ones(2, dtype=np.bool_))
+      state = _game_batch(env, np.ones(2, dtype=np.bool_))
       self.assertEqual(state.game.p0.character.tolist(), [
           melee.Character.FOX.value,
           melee.Character.FALCO.value,
@@ -215,7 +213,7 @@ class SimEnvTest(unittest.TestCase):
         character_pool='fox,falco',
     )
     try:
-      state = env.current_game_batch(np.ones(1, dtype=np.bool_))
+      state = _game_batch(env, np.ones(1, dtype=np.bool_))
       self.assertEqual(state.game.p0.character.tolist(), [
           melee.Character.FOX.value,
           melee.Character.FOX.value,
@@ -260,8 +258,7 @@ class SimEnvTest(unittest.TestCase):
         frame_buffer_length=8,
     )
     try:
-      state = env.current_game_batch(
-          needs_reset=np.ones(2, dtype=np.bool_))
+      state = _game_batch(env, np.ones(2, dtype=np.bool_))
       self.assertEqual(state.needs_reset.shape, (4,))
       self.assertEqual(state.game.p0.x.shape, (4,))
       self.assertEqual(state.game.p0.character[:2].tolist(), [
@@ -288,7 +285,7 @@ class SimEnvTest(unittest.TestCase):
           shoulder_spacing=4,
       )
       self.assertEqual(needs_reset.shape, (2,))
-      next_state = env.current_game_batch(needs_reset=needs_reset)
+      next_state = _game_batch(env, needs_reset)
       self.assertEqual(next_state.game.p0.x.shape, (4,))
     finally:
       env.stop()
@@ -342,8 +339,8 @@ class SimEnvTest(unittest.TestCase):
             encoded, axis_spacing=32, shoulder_spacing=4)
         np.testing.assert_array_equal(multi_reset, single_reset)
         _assert_game_batch_equal(
-            multi.current_game_batch(multi_reset),
-            single.current_game_batch(single_reset),
+            _game_batch(multi, multi_reset),
+            _game_batch(single, single_reset),
         )
     finally:
       single.stop()
@@ -375,8 +372,7 @@ class SimEnvTest(unittest.TestCase):
       env.step(controllers)
 
       port_state = env.current_state()
-      game_batch = env.current_game_batch(
-          needs_reset=np.array([False, True, False], dtype=np.bool_))
+      game_batch = _game_batch(env, np.array([False, True, False], dtype=np.bool_))
 
       port1 = port_state.gamestates[1]
       port2 = port_state.gamestates[2]
@@ -488,6 +484,14 @@ def _neutral_encoded_controller(batch_size: int):
 
 def _assert_game_batch_equal(actual, expected):
   jax.tree.map(np.testing.assert_array_equal, actual, expected)
+
+
+def _game_batch(env, needs_reset):
+  env.write_current_game(env.game_batch_buffers, needs_reset)
+  return observations.GameBatch(
+      game=env.game_batch_buffers.game,
+      needs_reset=env.game_batch_buffers.needs_reset,
+  )
 
 
 if __name__ == '__main__':

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -292,6 +292,62 @@ class SimEnvTest(unittest.TestCase):
     finally:
       env.stop()
 
+  def test_multiprocess_env_matches_single_process_encoded_steps(self):
+    players = [
+        {
+            1: dolphin.AI(melee.Character.FOX),
+            2: dolphin.AI(melee.Character.FALCO),
+        },
+        {
+            1: dolphin.AI(melee.Character.FALCO),
+            2: dolphin.AI(melee.Character.FOX),
+        },
+        {
+            1: dolphin.AI(melee.Character.FOX),
+            2: dolphin.AI(melee.Character.FOX),
+        },
+        {
+            1: dolphin.AI(melee.Character.FALCO),
+            2: dolphin.AI(melee.Character.FALCO),
+        },
+    ]
+    stages = [
+        melee.Stage.FINAL_DESTINATION,
+        melee.Stage.BATTLEFIELD,
+        melee.Stage.YOSHIS_STORY,
+        melee.Stage.POKEMON_STADIUM,
+    ]
+    single = self._sim_env(
+        num_envs=4,
+        players=players,
+        stage=stages,
+        frame_buffer_length=16,
+    )
+    multi = sim_env.MultiprocessSimEnvironment(
+        num_envs=4,
+        inner_batch_size=2,
+        players=players,
+        stage=stages,
+        frame_buffer_length=16,
+    )
+    try:
+      encoded = _neutral_encoded_controller(batch_size=8)
+      encoded.main_stick.x[:] = [16, 20, 12, 16, 16, 12, 20, 16]
+      encoded.buttons.A[:] = [False, True, False, True, True, False, True, False]
+      for _ in range(4):
+        single_reset = single.step_encoded(
+            encoded, axis_spacing=32, shoulder_spacing=4)
+        multi_reset = multi.step_encoded(
+            encoded, axis_spacing=32, shoulder_spacing=4)
+        np.testing.assert_array_equal(multi_reset, single_reset)
+        _assert_game_batch_equal(
+            multi.current_game_batch(multi_reset),
+            single.current_game_batch(single_reset),
+        )
+    finally:
+      single.stop()
+      multi.stop()
+
   def test_game_batch_matches_port_state_observation_conventions(self):
     env = self._sim_env(
         num_envs=3,
@@ -411,7 +467,7 @@ class SimEnvTest(unittest.TestCase):
     self.assertFalse(out.item_3.exists[0])
 
 def _neutral_encoded_controller(batch_size: int):
-  shape = (int(batch_size),)
+  shape = (batch_size,)
   return Controller(
       main_stick=Stick(
           x=np.full(shape, 16, dtype=np.uint8),
@@ -427,6 +483,35 @@ def _neutral_encoded_controller(batch_size: int):
           for name in Buttons._fields
       }),
   )
+
+
+def _assert_game_batch_equal(actual, expected):
+  for actual_leaf, expected_leaf in zip(
+      _game_batch_leaves(actual),
+      _game_batch_leaves(expected),
+  ):
+    np.testing.assert_array_equal(actual_leaf, expected_leaf)
+
+
+def _game_batch_leaves(game_batch):
+  return [
+      game_batch.needs_reset,
+      game_batch.game.p0.percent,
+      game_batch.game.p0.character,
+      game_batch.game.p0.action,
+      game_batch.game.p0.x,
+      game_batch.game.p0.y,
+      game_batch.game.p0.controller.main_stick.x,
+      game_batch.game.p0.controller.buttons.A,
+      game_batch.game.p1.percent,
+      game_batch.game.p1.character,
+      game_batch.game.p1.action,
+      game_batch.game.p1.x,
+      game_batch.game.p1.y,
+      game_batch.game.p1.controller.main_stick.x,
+      game_batch.game.p1.controller.buttons.A,
+      game_batch.game.stage,
+  ]
 
 
 if __name__ == '__main__':

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -12,14 +12,7 @@ from slippi_ai.types import Buttons, Controller, Items, Stick
 class SimEnvTest(unittest.TestCase):
 
   def _sim_env(self, *args, **kwargs):
-    try:
-      return sim_env.SimBatchedEnvironment(*args, **kwargs)
-    except MemoryError as exc:
-      if 'msl_batch_create failed' not in str(exc):
-        raise
-      self.skipTest(
-          'melee_sim EnvBatch could not initialize; set MELEE_SIM_DATA to an '
-          'extracted melee-sim-light data directory before running sim env tests.')
+    return sim_env.SimBatchedEnvironment(*args, **kwargs)
 
   def test_current_state_and_step_match_existing_game_shape(self):
     env = self._sim_env(
@@ -185,6 +178,32 @@ class SimEnvTest(unittest.TestCase):
               melee.Character.FALCO.value,
           ],
       )
+    finally:
+      env.stop()
+
+  def test_per_env_players_set_matchups(self):
+    env = self._sim_env(
+        num_envs=2,
+        frame_buffer_length=8,
+        players=[
+            {
+                1: dolphin.AI(melee.Character.FOX),
+                2: dolphin.AI(melee.Character.FALCO),
+            },
+            {
+                1: dolphin.AI(melee.Character.FALCO),
+                2: dolphin.AI(melee.Character.FOX),
+            },
+        ],
+    )
+    try:
+      state = env.current_game_batch(np.ones(2, dtype=np.bool_))
+      self.assertEqual(state.game.p0.character.tolist(), [
+          melee.Character.FOX.value,
+          melee.Character.FALCO.value,
+          melee.Character.FALCO.value,
+          melee.Character.FOX.value,
+      ])
     finally:
       env.stop()
 

--- a/tests/test_sim_env.py
+++ b/tests/test_sim_env.py
@@ -1,5 +1,6 @@
 import unittest
 
+import jax
 import melee
 import numpy as np
 
@@ -486,32 +487,7 @@ def _neutral_encoded_controller(batch_size: int):
 
 
 def _assert_game_batch_equal(actual, expected):
-  for actual_leaf, expected_leaf in zip(
-      _game_batch_leaves(actual),
-      _game_batch_leaves(expected),
-  ):
-    np.testing.assert_array_equal(actual_leaf, expected_leaf)
-
-
-def _game_batch_leaves(game_batch):
-  return [
-      game_batch.needs_reset,
-      game_batch.game.p0.percent,
-      game_batch.game.p0.character,
-      game_batch.game.p0.action,
-      game_batch.game.p0.x,
-      game_batch.game.p0.y,
-      game_batch.game.p0.controller.main_stick.x,
-      game_batch.game.p0.controller.buttons.A,
-      game_batch.game.p1.percent,
-      game_batch.game.p1.character,
-      game_batch.game.p1.action,
-      game_batch.game.p1.x,
-      game_batch.game.p1.y,
-      game_batch.game.p1.controller.main_stick.x,
-      game_batch.game.p1.controller.buttons.A,
-      game_batch.game.stage,
-  ]
+  jax.tree.map(np.testing.assert_array_equal, actual, expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a multiprocessing env wrapper for the JAX sim rollout worker to use. The parent process keeps policy inference and trajectory assembly, and worker processes each own a shard of SimBatchedEnvironment and write observations/resets into shared memory. Uses the same `num_envs / inner_batch_size = worker count` logic as the dolphin multiprocessing env code, and is enabled by `async_envs=True`. Doesn't support `num_env_steps` for now.


benchmarking in run_evaluator.py:
```
Settings:
4096 envs, rollout_length=3000, inner_batch_size=256

Non-MP:
timings: {'env_push': '27.776', 'agent_step': '5.610', 'trajectory_build': '7.411'}
env_fps: 97938.49, player_fps: 195876.99, sps: 23.91

MP 16 x 256:
timings: {'env_push': '4.066', 'agent_step': '5.470', 'trajectory_build': '12.154'}
env_fps: 179583.63, player_fps: 359167.25, sps: 43.84
```

Also verified a 100-step sim RL test run using the multiprocess env still trains - the trained checkpoint beat the base checkpoint 92-8 over 100 sim games.